### PR TITLE
feat(processor): symbolicate the stack lines via the symbolic-go library

### DIFF
--- a/processor/config.go
+++ b/processor/config.go
@@ -2,19 +2,24 @@ package symbolicatorprocessor
 
 // Config defines configuration for the symbolicator processor.
 type Config struct {
-	// ColumnsAttributeKey is the attribute key that contains the column numbers of the stack trace.
+	// ColumnsAttributeKey is the attribute key that contains the column numbers
+	// of the stack trace.
 	ColumnsAttributeKey string `mapstructure:"columns_attribute_key"`
 
-	// FunctionsAttributeKey is the attribute key that contains the function names of the stack trace.
+	// FunctionsAttributeKey is the attribute key that contains the function
+	// names of the stack trace.
 	FunctionsAttributeKey string `mapstructure:"functions_attribute_key"`
 
-	// LinesAttributeKey is the attribute key that contains the line numbers of the stack trace.
+	// LinesAttributeKey is the attribute key that contains the line numbers of
+	// the stack trace.
 	LinesAttributeKey string `mapstructure:"lines_attribute_key"`
 
-	// UrlsAttributeKey is the attribute key that contains the URLs of the stack trace.
+	// UrlsAttributeKey is the attribute key that contains the URLs of the stack
+	// trace.
 	UrlsAttributeKey string `mapstructure:"urls_attribute_key"`
 
-	// OutputStackTraceKey is the attribute key that the symbolicated stack trace will be written to.
+	// OutputStackTraceKey is the attribute key that the symbolicated stack trace
+	// will be written to.
 	OutputStackTraceKey string `mapstructure:"output_stack_trace_key"`
 }
 

--- a/processor/config.go
+++ b/processor/config.go
@@ -21,6 +21,10 @@ type Config struct {
 	// OutputStackTraceKey is the attribute key that the symbolicated stack trace
 	// will be written to.
 	OutputStackTraceKey string `mapstructure:"output_stack_trace_key"`
+
+	// SourceMapFilePath is a file path to where the minified source and source
+	// maps are stored on disk
+	SourceMapFilePath string `mapstructure:"source_map_file_path"`
 }
 
 // Validate checks the configuration for any issues.

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -27,7 +27,9 @@ func createDefaultConfig() component.Config {
 // createTracesProcessor creates a traces processor
 func createTracesProcessor(ctx context.Context, set processor.Settings, cfg component.Config, next consumer.Traces) (processor.Traces, error) {
 	symCfg := cfg.(*Config)
-	processor := newSymbolicatorProcessor(ctx, symCfg, set, &noopSymbolicator{})
+	fs := newFileStore(symCfg.SourceMapFilePath, set.Logger)
+	sym := newBasicSymbolicator(fs)
+	processor := newSymbolicatorProcessor(ctx, symCfg, set, sym)
 	return processorhelper.NewTraces(ctx, set, cfg, next, processor.processTraces, processorhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}))
 }
 

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -21,6 +21,7 @@ func createDefaultConfig() component.Config {
 		LinesAttributeKey:     "exception.structured_stacktrace.lines",
 		UrlsAttributeKey:      "exception.structured_stacktrace.urls",
 		OutputStackTraceKey:   "exception.stacktrace",
+		SourceMapFilePath:     ".",
 	}
 }
 

--- a/processor/file_store.go
+++ b/processor/file_store.go
@@ -1,0 +1,59 @@
+package symbolicatorprocessor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"go.uber.org/zap"
+)
+
+var (
+	mappingURLRegex                  = regexp.MustCompile(`\/\/[#@]\s(source(?:Mapping)?URL)=\s*(\S+)`)
+	errFailedToFindSourceFile        = fmt.Errorf("failed to find source file")
+	errFailedToFindSourceMapLocation = fmt.Errorf("failed to find source map location")
+	errFailedToFindSourceMap         = fmt.Errorf("failed to find source map")
+)
+
+type fileStore struct {
+	logger *zap.Logger
+	root   string
+}
+
+func newFileStore(root string, logger *zap.Logger) *fileStore {
+	return &fileStore{
+		logger: logger,
+		root:   root,
+	}
+}
+
+func (fs *fileStore) GetSourceMap(ctx context.Context, url string) (string, string, error) {
+	source, err := os.ReadFile(filepath.Join(fs.root, url))
+
+	if err != nil {
+		return "", "", fmt.Errorf("%w: %s", errFailedToFindSourceFile, url)
+	}
+
+	fs.logger.Info("Found source file", zap.String("path", filepath.Join(fs.root, url)))
+
+	matches := mappingURLRegex.FindStringSubmatch(string(source))
+
+	if len(matches) <= 0 {
+		return string(source), "", fmt.Errorf("%w: %s", errFailedToFindSourceMapLocation, url)
+	}
+
+	// the capture group we want is the last one
+	mapName := matches[len(matches)-1]
+
+	sourceMap, err := os.ReadFile(filepath.Join(fs.root, mapName))
+
+	if err != nil {
+		return string(source), "", fmt.Errorf("%w: %s", errFailedToFindSourceMap, mapName)
+	}
+
+	fs.logger.Info("Found map file", zap.String("path", filepath.Join(fs.root, mapName)))
+
+	return string(source), string(sourceMap), nil
+}

--- a/processor/file_store_test.go
+++ b/processor/file_store_test.go
@@ -1,0 +1,24 @@
+package symbolicatorprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFileStore(t *testing.T) {
+	ctx := context.Background()
+
+	fs := newFileStore("../test_assets", zaptest.NewLogger(t))
+
+	source, sMap, err := fs.GetSourceMap(ctx, "basic-mapping.js")
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, source)
+	assert.NotEmpty(t, sMap)
+
+	source, sMap, err = fs.GetSourceMap(ctx, "does-not-exist.js")
+	assert.ErrorIs(t, err, errFailedToFindSourceFile)
+}

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -22,6 +22,14 @@ func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
 
 // symbolicate does nothing and returns an empty string.
 func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, error) {
+	if column < 0 || column > math.MaxUint32 {
+		return "", fmt.Errorf("column must be uint32: %d", column)
+	}
+
+	if line < 0 || line > math.MaxUint32 {
+		return "", fmt.Errorf("line must be uint32: %d", line)
+	}
+
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
 	source, sMap, err := ns.store.GetSourceMap(ctx, url)
 
@@ -35,14 +43,6 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 
 	if err != nil {
 		return "", err
-	}
-
-	if column < 0 || column > math.MaxUint32 {
-		return "", fmt.Errorf("column must be uint32: %d", column)
-	}
-
-	if line < 0 || line > math.MaxUint32 {
-		return "", fmt.Errorf("line must be uint32: %d", line)
 	}
 
 	t, err := smc.Lookup(uint32(line), uint32(column), 0)

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -20,7 +20,7 @@ func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
 	return &basicSymbolicator{store: store}
 }
 
-// symbolicate does nothing and returns an empty string.
+// symbolicate takes a line, column, function name, and URL and returns a string
 func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, error) {
 	if column < 0 || column > math.MaxUint32 {
 		return "", fmt.Errorf("column must be uint32: %d", column)
@@ -38,7 +38,9 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 	}
 
 	// Create a new source map cache
-	// TODO: we should cache this
+	// TODO: we should cache this but they are not thread safe
+	// so we need to lock around them
+	// TODO: we should also have a way to evict old source maps
 	smc, err := symbolic.NewSourceMapCache(source, sMap)
 
 	if err != nil {

--- a/processor/symbolicator_test.go
+++ b/processor/symbolicator_test.go
@@ -1,0 +1,31 @@
+package symbolicatorprocessor
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestSymbolicator(t *testing.T) {
+	ctx := context.Background()
+
+	fs := newFileStore("../test_assets", zaptest.NewLogger(t))
+	sym := newBasicSymbolicator(fs)
+
+	line, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "at bar(basic-mapping-original.js:8:1)", line)
+
+	line, err = sym.symbolicate(ctx, 0, 34, "b", "does-not-exist.js")
+	assert.Error(t, err)
+
+	_, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", "basic-mapping.js")
+	assert.Error(t, err)
+
+	_, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", "basic-mapping.js")
+	assert.Error(t, err)
+}

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -27,14 +27,14 @@ func (ts *testSymbolicator) clear() {
 	ts.SymbolicatedLines = nil
 }
 
-func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) string {
+func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, error) {
 	ts.SymbolicatedLines = append(ts.SymbolicatedLines, symbolicatedLine{
 		Line:     line,
 		Column:   column,
 		Function: function,
 		URL:      url,
 	})
-	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url)
+	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), nil
 }
 
 func TestProcess(t *testing.T) {

--- a/test_assets/basic-mapping.js
+++ b/test_assets/basic-mapping.js
@@ -1,0 +1,2 @@
+function foo() { return 42 } function bar() { return 24 } foo(); bar();
+//# sourceMappingURL=basic-mapping.js.map

--- a/test_assets/basic-mapping.js.map
+++ b/test_assets/basic-mapping.js.map
@@ -1,0 +1,6 @@
+{
+  "version":3,
+  "names": ["foo","bar"],
+  "sources": ["basic-mapping-original.js"],
+  "mappings":"AAAA,SAASA,MACP,OAAO,EACT,CACA,SAASC,MACP,OAAO,EACT,CACAD,MACAC"
+}


### PR DESCRIPTION
## Short description of the changes

- Adds a basic file store for retrieving stored source maps and minified files
- naively calls into the symbolic-go library to symbolicate the lines of the stack trace

## How to verify that this has the expected result
