### PR TITLE
feat(processor): Add attributes to preserve the original stacktrace

### DIFF
--- a/processor/config.go
+++ b/processor/config.go
@@ -22,27 +22,31 @@ type Config struct {
 	// will be written to.
 	OutputStackTraceKey string `mapstructure:"output_stack_trace_key"`
 
+	// preserveStackTrace is a config option that determines whether to keep the
+	// original stack trace in the output.
+	PreserveStackTrace bool `mapstructure:"preserve_stack_trace"`
+
 	// OriginalStackTraceKey is the attribute key that preserves the original stack 
-	// trace
+	// trace.
 	OriginalStackTraceKey string `mapstructure:"original_stack_trace_key"`
 
 	// OriginalColumnsAttributeKey is the attribute key that preserves the original
-	// column numbers
+	// column numbers.
 	OriginalColumnsAttributeKey string `mapstructure:"original_columns_attribute_key"`
 
 	// OriginalFunctionsAttributeKey is the attribute key that preserves the original
-	// function names
+	// function names.
 	OriginalFunctionsAttributeKey string `mapstructure:"original_functions_attribute_key"`
 
 	// OriginalLinesAttributeKey is the attribute key that preserves the original
-	// line numbers
+	// line numbers.
 	OriginalLinesAttributeKey string `mapstructure:"original_lines_attribute_key"`
 
-	// OriginalUrlsAttributeKey is the attribute key that preserves the original URLs
+	// OriginalUrlsAttributeKey is the attribute key that preserves the original URLs.
 	OriginalUrlsAttributeKey string `mapstructure:"original_urls_attribute_key"`
 
 	// SourceMapFilePath is a file path to where the minified source and source
-	// maps are stored on disk
+	// maps are stored on disk.
 	SourceMapFilePath string `mapstructure:"source_map_file_path"`
 }
 

--- a/processor/config.go
+++ b/processor/config.go
@@ -22,6 +22,25 @@ type Config struct {
 	// will be written to.
 	OutputStackTraceKey string `mapstructure:"output_stack_trace_key"`
 
+	// OriginalStackTraceKey is the attribute key that preserves the original stack 
+	// trace
+	OriginalStackTraceKey string `mapstructure:"original_stack_trace_key"`
+
+	// OriginalColumnsAttributeKey is the attribute key that preserves the original
+	// column numbers
+	OriginalColumnsAttributeKey string `mapstructure:"original_columns_attribute_key"`
+
+	// OriginalFunctionsAttributeKey is the attribute key that preserves the original
+	// function names
+	OriginalFunctionsAttributeKey string `mapstructure:"original_functions_attribute_key"`
+
+	// OriginalLinesAttributeKey is the attribute key that preserves the original
+	// line numbers
+	OriginalLinesAttributeKey string `mapstructure:"original_lines_attribute_key"`
+
+	// OriginalUrlsAttributeKey is the attribute key that preserves the original URLs
+	OriginalUrlsAttributeKey string `mapstructure:"original_urls_attribute_key"`
+
 	// SourceMapFilePath is a file path to where the minified source and source
 	// maps are stored on disk
 	SourceMapFilePath string `mapstructure:"source_map_file_path"`

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -21,6 +21,7 @@ func createDefaultConfig() component.Config {
 		LinesAttributeKey:     "exception.structured_stacktrace.lines",
 		UrlsAttributeKey:      "exception.structured_stacktrace.urls",
 		OutputStackTraceKey:   "exception.stacktrace",
+		PreserveStackTrace: true,
 		OriginalStackTraceKey: "exception.stacktrace.original",
 		OriginalFunctionsAttributeKey: "exception.structured_stacktrace.functions.original",
 		OriginalLinesAttributeKey:     "exception.structured_stacktrace.lines.original",

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -21,6 +21,11 @@ func createDefaultConfig() component.Config {
 		LinesAttributeKey:     "exception.structured_stacktrace.lines",
 		UrlsAttributeKey:      "exception.structured_stacktrace.urls",
 		OutputStackTraceKey:   "exception.stacktrace",
+		OriginalStackTraceKey: "exception.stacktrace.original",
+		OriginalFunctionsAttributeKey: "exception.structured_stacktrace.columns.original",
+		OriginalLinesAttributeKey:     "exception.structured_stacktrace.lines.original",
+		OriginalColumnsAttributeKey:   "exception.structured_stacktrace.functions.original",
+		OriginalUrlsAttributeKey:      "exception.structured_stacktrace.urls.original",
 		SourceMapFilePath:     ".",
 	}
 }

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -22,9 +22,9 @@ func createDefaultConfig() component.Config {
 		UrlsAttributeKey:      "exception.structured_stacktrace.urls",
 		OutputStackTraceKey:   "exception.stacktrace",
 		OriginalStackTraceKey: "exception.stacktrace.original",
-		OriginalFunctionsAttributeKey: "exception.structured_stacktrace.columns.original",
+		OriginalFunctionsAttributeKey: "exception.structured_stacktrace.functions.original",
 		OriginalLinesAttributeKey:     "exception.structured_stacktrace.lines.original",
-		OriginalColumnsAttributeKey:   "exception.structured_stacktrace.functions.original",
+		OriginalColumnsAttributeKey:   "exception.structured_stacktrace.columns.original",
 		OriginalUrlsAttributeKey:      "exception.structured_stacktrace.urls.original",
 		SourceMapFilePath:     ".",
 	}

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -101,6 +101,23 @@ func (sp *symbolicatorProcessor) processAttributes(ctx context.Context, attribut
 		)
 	}
 
+	// Preserve original stack trace
+	var origColumns = attributes.PutEmptySlice(sp.cfg.OriginalColumnsAttributeKey)
+	columns.CopyTo(origColumns)
+
+	var origFunctions = attributes.PutEmptySlice(sp.cfg.OriginalFunctionsAttributeKey)
+	functions.CopyTo(origFunctions)
+
+	var origLines = attributes.PutEmptySlice(sp.cfg.OriginalLinesAttributeKey)
+	lines.CopyTo(origLines)
+
+	var origUrls = attributes.PutEmptySlice(sp.cfg.OriginalUrlsAttributeKey)
+	urls.CopyTo(origUrls)
+
+	var origStackTraceStr, _ = attributes.Get(sp.cfg.OriginalStackTraceKey)
+	attributes.PutStr(sp.cfg.OriginalStackTraceKey, origStackTraceStr.Str())
+
+	// Update with symbolicated stack trace
 	var stack []string
 
 	for i := 0; i < columns.Len(); i++ {

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -114,7 +114,7 @@ func (sp *symbolicatorProcessor) processAttributes(ctx context.Context, attribut
 	var origUrls = attributes.PutEmptySlice(sp.cfg.OriginalUrlsAttributeKey)
 	urls.CopyTo(origUrls)
 
-	var origStackTraceStr, _ = attributes.Get(sp.cfg.OriginalStackTraceKey)
+	var origStackTraceStr, _ = attributes.Get(sp.cfg.OutputStackTraceKey)
 	attributes.PutStr(sp.cfg.OriginalStackTraceKey, origStackTraceStr.Str())
 
 	// Update with symbolicated stack trace

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -102,20 +102,22 @@ func (sp *symbolicatorProcessor) processAttributes(ctx context.Context, attribut
 	}
 
 	// Preserve original stack trace
-	var origColumns = attributes.PutEmptySlice(sp.cfg.OriginalColumnsAttributeKey)
-	columns.CopyTo(origColumns)
+	if (sp.cfg.PreserveStackTrace) {
+		var origColumns = attributes.PutEmptySlice(sp.cfg.OriginalColumnsAttributeKey)
+		columns.CopyTo(origColumns)
 
-	var origFunctions = attributes.PutEmptySlice(sp.cfg.OriginalFunctionsAttributeKey)
-	functions.CopyTo(origFunctions)
+		var origFunctions = attributes.PutEmptySlice(sp.cfg.OriginalFunctionsAttributeKey)
+		functions.CopyTo(origFunctions)
 
-	var origLines = attributes.PutEmptySlice(sp.cfg.OriginalLinesAttributeKey)
-	lines.CopyTo(origLines)
+		var origLines = attributes.PutEmptySlice(sp.cfg.OriginalLinesAttributeKey)
+		lines.CopyTo(origLines)
 
-	var origUrls = attributes.PutEmptySlice(sp.cfg.OriginalUrlsAttributeKey)
-	urls.CopyTo(origUrls)
+		var origUrls = attributes.PutEmptySlice(sp.cfg.OriginalUrlsAttributeKey)
+		urls.CopyTo(origUrls)
 
-	var origStackTraceStr, _ = attributes.Get(sp.cfg.OutputStackTraceKey)
-	attributes.PutStr(sp.cfg.OriginalStackTraceKey, origStackTraceStr.Str())
+		var origStackTraceStr, _ = attributes.Get(sp.cfg.OutputStackTraceKey)
+		attributes.PutStr(sp.cfg.OriginalStackTraceKey, origStackTraceStr.Str())
+	}
 
 	// Update with symbolicated stack trace
 	var stack []string

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -75,6 +75,8 @@ func TestProcess(t *testing.T) {
 				assert.Equal(t, "symbolicated 42:42 function url", attr.Str())
 			},
 		},
+		// Add unit tests to include attributes preserving stack trace
+		// Add unit test testing the preserveStackTrace option
 		{
 			Name: "missing columns attribute",
 			ApplyAttributes: func(span ptrace.Span) {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
Adds extra attributes to preserve the stack trace before it is symbolicated. Also adds a `preserve_stack_trace` config option (which can be set in the `config.yaml` file under `symbolicator`) to decide if the extra attributes should be added.

`preserve_stack_trace` is set to true by default, for now.

## How to verify that this has the expected result
I tested the collector locally and confirmed that the output is what I expected.

I attached a screenshot of the output that was sent to Honeycomb below:
![image](https://github.com/user-attachments/assets/8e4415ad-5923-4a73-a94d-c17b9758a364)

With the `preserve_stack_trace` config option:
<img width="1458" alt="Screenshot 2024-11-25 at 2 18 37 PM" src="https://github.com/user-attachments/assets/96826cd3-3d1d-48ca-b111-034bd2a3ffcd">


