### PR TITLE
feat(processor): Add extra symbolicated attributes

### DIFF
--- a/processor/config.go
+++ b/processor/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	// original stack trace in the output.
 	PreserveStackTrace bool `mapstructure:"preserve_stack_trace"`
 
-	// OriginalStackTraceKey is the attribute key that preserves the original stack 
+	// OriginalStackTraceKey is the attribute key that preserves the original stack
 	// trace.
 	OriginalStackTraceKey string `mapstructure:"original_stack_trace_key"`
 

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -16,18 +16,18 @@ var (
 // createDefaultConfig creates the default configuration for the processor.
 func createDefaultConfig() component.Config {
 	return &Config{
-		ColumnsAttributeKey:   "exception.structured_stacktrace.columns",
-		FunctionsAttributeKey: "exception.structured_stacktrace.functions",
-		LinesAttributeKey:     "exception.structured_stacktrace.lines",
-		UrlsAttributeKey:      "exception.structured_stacktrace.urls",
-		OutputStackTraceKey:   "exception.stacktrace",
-		PreserveStackTrace: true,
-		OriginalStackTraceKey: "exception.stacktrace.original",
+		ColumnsAttributeKey:           "exception.structured_stacktrace.columns",
+		FunctionsAttributeKey:         "exception.structured_stacktrace.functions",
+		LinesAttributeKey:             "exception.structured_stacktrace.lines",
+		UrlsAttributeKey:              "exception.structured_stacktrace.urls",
+		OutputStackTraceKey:           "exception.stacktrace",
+		PreserveStackTrace:            true,
+		OriginalStackTraceKey:         "exception.stacktrace.original",
 		OriginalFunctionsAttributeKey: "exception.structured_stacktrace.functions.original",
 		OriginalLinesAttributeKey:     "exception.structured_stacktrace.lines.original",
 		OriginalColumnsAttributeKey:   "exception.structured_stacktrace.columns.original",
 		OriginalUrlsAttributeKey:      "exception.structured_stacktrace.urls.original",
-		SourceMapFilePath:     ".",
+		SourceMapFilePath:             ".",
 	}
 }
 

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -28,20 +28,20 @@ type MappedStackFrame struct {
 }
 
 // symbolicate takes a line, column, function name, and URL and returns a string
-func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, MappedStackFrame, error) {
+func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, *MappedStackFrame, error) {
 	if column < 0 || column > math.MaxUint32 {
-		return "", MappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
+		return "", &MappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
 	}
 
 	if line < 0 || line > math.MaxUint32 {
-		return "", MappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
+		return "", &MappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
 	source, sMap, err := ns.store.GetSourceMap(ctx, url)
 
 	if err != nil {
-		return "", MappedStackFrame{}, err
+		return "", &MappedStackFrame{}, err
 	}
 
 	// Create a new source map cache
@@ -51,16 +51,16 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 	smc, err := symbolic.NewSourceMapCache(source, sMap)
 
 	if err != nil {
-		return "", MappedStackFrame{}, err
+		return "", &MappedStackFrame{}, err
 	}
 
 	t, err := smc.Lookup(uint32(line), uint32(column), 0)
 
 	if err != nil {
-		return "", MappedStackFrame{}, err
+		return "", &MappedStackFrame{}, err
 	}
 
-	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), MappedStackFrame{
+	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), &MappedStackFrame{
 		FunctionName: t.FunctionName,
 		URL:          t.Src,
 		Line:         int64(t.Line),

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -28,20 +28,20 @@ type MappedStackFrame struct {
 }
 
 // symbolicate takes a line, column, function name, and URL and returns a string
-func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, *MappedStackFrame, error) {
+func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (*MappedStackFrame, error) {
 	if column < 0 || column > math.MaxUint32 {
-		return "", &MappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
+		return &MappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
 	}
 
 	if line < 0 || line > math.MaxUint32 {
-		return "", &MappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
+		return &MappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
 	source, sMap, err := ns.store.GetSourceMap(ctx, url)
 
 	if err != nil {
-		return "", &MappedStackFrame{}, err
+		return &MappedStackFrame{}, err
 	}
 
 	// Create a new source map cache
@@ -51,16 +51,16 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 	smc, err := symbolic.NewSourceMapCache(source, sMap)
 
 	if err != nil {
-		return "", &MappedStackFrame{}, err
+		return &MappedStackFrame{}, err
 	}
 
 	t, err := smc.Lookup(uint32(line), uint32(column), 0)
 
 	if err != nil {
-		return "", &MappedStackFrame{}, err
+		return &MappedStackFrame{}, err
 	}
 
-	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), &MappedStackFrame{
+	return &MappedStackFrame{
 		FunctionName: t.FunctionName,
 		URL:          t.Src,
 		Line:         int64(t.Line),

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -20,21 +20,28 @@ func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
 	return &basicSymbolicator{store: store}
 }
 
+type MappedStackFrame struct {
+	FunctionName string
+	Src          string
+	Line		 int64
+	Col 		 int64
+}
+
 // symbolicate takes a line, column, function name, and URL and returns a string
-func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, error) {
+func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, MappedStackFrame, error) {
 	if column < 0 || column > math.MaxUint32 {
-		return "", fmt.Errorf("column must be uint32: %d", column)
+		return "", MappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
 	}
 
 	if line < 0 || line > math.MaxUint32 {
-		return "", fmt.Errorf("line must be uint32: %d", line)
+		return "", MappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
 	source, sMap, err := ns.store.GetSourceMap(ctx, url)
 
 	if err != nil {
-		return "", err
+		return "", MappedStackFrame{}, err
 	}
 
 	// Create a new source map cache
@@ -44,14 +51,19 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 	smc, err := symbolic.NewSourceMapCache(source, sMap)
 
 	if err != nil {
-		return "", err
+		return "", MappedStackFrame{}, err
 	}
 
 	t, err := smc.Lookup(uint32(line), uint32(column), 0)
 
 	if err != nil {
-		return "", err
+		return "", MappedStackFrame{}, err
 	}
 
-	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), nil
+	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), MappedStackFrame{
+			FunctionName: t.FunctionName,
+			Src: t.Src,
+			Line: int64(t.Line),
+			Col: int64(t.Col),
+		}, nil
 }

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -20,7 +20,7 @@ func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
 	return &basicSymbolicator{store: store}
 }
 
-type MappedStackFrame struct {
+type mappedStackFrame struct {
 	FunctionName string
 	URL          string
 	Line         int64
@@ -28,20 +28,20 @@ type MappedStackFrame struct {
 }
 
 // symbolicate takes a line, column, function name, and URL and returns a string
-func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (*MappedStackFrame, error) {
+func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (*mappedStackFrame, error) {
 	if column < 0 || column > math.MaxUint32 {
-		return &MappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
+		return &mappedStackFrame{}, fmt.Errorf("column must be uint32: %d", column)
 	}
 
 	if line < 0 || line > math.MaxUint32 {
-		return &MappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
+		return &mappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
 	source, sMap, err := ns.store.GetSourceMap(ctx, url)
 
 	if err != nil {
-		return &MappedStackFrame{}, err
+		return &mappedStackFrame{}, err
 	}
 
 	// Create a new source map cache
@@ -51,16 +51,16 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 	smc, err := symbolic.NewSourceMapCache(source, sMap)
 
 	if err != nil {
-		return &MappedStackFrame{}, err
+		return &mappedStackFrame{}, err
 	}
 
 	t, err := smc.Lookup(uint32(line), uint32(column), 0)
 
 	if err != nil {
-		return &MappedStackFrame{}, err
+		return &mappedStackFrame{}, err
 	}
 
-	return &MappedStackFrame{
+	return &mappedStackFrame{
 		FunctionName: t.FunctionName,
 		URL:          t.Src,
 		Line:         int64(t.Line),

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -23,8 +23,8 @@ func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
 type MappedStackFrame struct {
 	FunctionName string
 	URL          string
-	Line		 int64
-	Col 		 int64
+	Line         int64
+	Col          int64
 }
 
 // symbolicate takes a line, column, function name, and URL and returns a string
@@ -61,9 +61,9 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 	}
 
 	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), MappedStackFrame{
-			FunctionName: t.FunctionName,
-			URL: t.Src,
-			Line: int64(t.Line),
-			Col: int64(t.Col),
-		}, nil
+		FunctionName: t.FunctionName,
+		URL:          t.Src,
+		Line:         int64(t.Line),
+		Col:          int64(t.Col),
+	}, nil
 }

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -22,7 +22,7 @@ func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
 
 type MappedStackFrame struct {
 	FunctionName string
-	Src          string
+	URL          string
 	Line		 int64
 	Col 		 int64
 }
@@ -62,7 +62,7 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 
 	return fmt.Sprintf("at %s(%s:%d:%d)", t.FunctionName, t.Src, t.Line, t.Col), MappedStackFrame{
 			FunctionName: t.FunctionName,
-			Src: t.Src,
+			URL: t.Src,
 			Line: int64(t.Line),
 			Col: int64(t.Col),
 		}, nil

--- a/processor/symbolicator_test.go
+++ b/processor/symbolicator_test.go
@@ -15,17 +15,18 @@ func TestSymbolicator(t *testing.T) {
 	fs := newFileStore("../test_assets", zaptest.NewLogger(t))
 	sym := newBasicSymbolicator(fs)
 
-	line, _, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
+	sf, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
+	line := formatStackFrame(sf)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "at bar(basic-mapping-original.js:8:1)", line)
 
-	_, _, err = sym.symbolicate(ctx, 0, 34, "b", "does-not-exist.js")
+	_, err = sym.symbolicate(ctx, 0, 34, "b", "does-not-exist.js")
 	assert.Error(t, err)
 
-	_, _, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", "basic-mapping.js")
+	_, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", "basic-mapping.js")
 	assert.Error(t, err)
 
-	_, _, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", "basic-mapping.js")
+	_, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", "basic-mapping.js")
 	assert.Error(t, err)
 }

--- a/processor/symbolicator_test.go
+++ b/processor/symbolicator_test.go
@@ -15,17 +15,17 @@ func TestSymbolicator(t *testing.T) {
 	fs := newFileStore("../test_assets", zaptest.NewLogger(t))
 	sym := newBasicSymbolicator(fs)
 
-	line, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
+	line, _, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "at bar(basic-mapping-original.js:8:1)", line)
 
-	line, err = sym.symbolicate(ctx, 0, 34, "b", "does-not-exist.js")
+	_, _, err = sym.symbolicate(ctx, 0, 34, "b", "does-not-exist.js")
 	assert.Error(t, err)
 
-	_, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", "basic-mapping.js")
+	_, _, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", "basic-mapping.js")
 	assert.Error(t, err)
 
-	_, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", "basic-mapping.js")
+	_, _, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", "basic-mapping.js")
 	assert.Error(t, err)
 }

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -102,7 +102,7 @@ func (sp *symbolicatorProcessor) processAttributes(ctx context.Context, attribut
 	}
 
 	// Preserve original stack trace
-	if (sp.cfg.PreserveStackTrace) {
+	if sp.cfg.PreserveStackTrace {
 		var origColumns = attributes.PutEmptySlice(sp.cfg.OriginalColumnsAttributeKey)
 		columns.CopyTo(origColumns)
 
@@ -125,17 +125,16 @@ func (sp *symbolicatorProcessor) processAttributes(ctx context.Context, attribut
 	var mappedFunctions = attributes.PutEmptySlice(sp.cfg.FunctionsAttributeKey)
 	var mappedLines = attributes.PutEmptySlice(sp.cfg.LinesAttributeKey)
 	var mappedUrls = attributes.PutEmptySlice(sp.cfg.UrlsAttributeKey)
-	
 
 	for i := 0; i < columns.Len(); i++ {
 		s, mappedStackFrame, err := sp.symbolicator.symbolicate(ctx, lines.At(i).Int(), columns.At(i).Int(), functions.At(i).Str(), urls.At(i).Str())
 
 		if err != nil {
 			stack = append(stack, fmt.Sprintf("Failed to symbolicate: %v", err))
-			mappedColumns.AppendEmpty().SetInt(columns.At(i).Int())
-			mappedFunctions.AppendEmpty().SetStr(functions.At(i).Str())
-			mappedLines.AppendEmpty().SetInt(lines.At(i).Int())
-			mappedUrls.AppendEmpty().SetStr(urls.At(i).Str())
+			mappedColumns.AppendEmpty().SetInt(-1)
+			mappedFunctions.AppendEmpty().SetStr("")
+			mappedLines.AppendEmpty().SetInt(-1)
+			mappedUrls.AppendEmpty().SetStr("")
 		} else {
 			stack = append(stack, s)
 			mappedColumns.AppendEmpty().SetInt(mappedStackFrame.Col)

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -19,7 +19,7 @@ var (
 
 // symbolicator interface is used to symbolicate stack traces.
 type symbolicator interface {
-	symbolicate(ctx context.Context, line, column int64, function, url string) (string, MappedStackFrame, error)
+	symbolicate(ctx context.Context, line, column int64, function, url string) (string, *MappedStackFrame, error)
 }
 
 // symbolicatorProcessor is a processor that finds and symbolicates stack

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -141,7 +141,7 @@ func (sp *symbolicatorProcessor) processAttributes(ctx context.Context, attribut
 			mappedColumns.AppendEmpty().SetInt(mappedStackFrame.Col)
 			mappedFunctions.AppendEmpty().SetStr(mappedStackFrame.FunctionName)
 			mappedLines.AppendEmpty().SetInt(mappedStackFrame.Line)
-			mappedUrls.AppendEmpty().SetStr(mappedStackFrame.Src)
+			mappedUrls.AppendEmpty().SetStr(mappedStackFrame.URL)
 		}
 	}
 

--- a/processor/trace_processor.go
+++ b/processor/trace_processor.go
@@ -19,7 +19,7 @@ var (
 
 // symbolicator interface is used to symbolicate stack traces.
 type symbolicator interface {
-	symbolicate(ctx context.Context, line, column int64, function, url string) (*MappedStackFrame, error)
+	symbolicate(ctx context.Context, line, column int64, function, url string) (*mappedStackFrame, error)
 }
 
 // symbolicatorProcessor is a processor that finds and symbolicates stack
@@ -73,7 +73,7 @@ func (sp *symbolicatorProcessor) processResourceSpans(ctx context.Context, rs pt
 
 // formatStackFrame takes a MappedStackFrame struct and returns a string representation of the stack frame
 // TODO: Update to consider different browser formats
-func formatStackFrame(sf *MappedStackFrame) string {
+func formatStackFrame(sf *mappedStackFrame) string {
 	return fmt.Sprintf("at %s(%s:%d:%d)", sf.FunctionName, sf.URL, sf.Line, sf.Col)
 }
 

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -27,14 +27,14 @@ func (ts *testSymbolicator) clear() {
 	ts.SymbolicatedLines = nil
 }
 
-func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, MappedStackFrame, error) {
+func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, *MappedStackFrame, error) {
 	ts.SymbolicatedLines = append(ts.SymbolicatedLines, symbolicatedLine{
 		Line:     line,
 		Column:   column,
 		Function: function,
 		URL:      url,
 	})
-	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), MappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
+	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), &MappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
 }
 
 func TestProcess(t *testing.T) {

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -27,14 +27,14 @@ func (ts *testSymbolicator) clear() {
 	ts.SymbolicatedLines = nil
 }
 
-func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, error) {
+func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, MappedStackFrame, error) {
 	ts.SymbolicatedLines = append(ts.SymbolicatedLines, symbolicatedLine{
 		Line:     line,
 		Column:   column,
 		Function: function,
 		URL:      url,
 	})
-	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), nil
+	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), MappedStackFrame{}, nil
 }
 
 func TestProcess(t *testing.T) {

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -34,7 +34,7 @@ func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64,
 		Function: function,
 		URL:      url,
 	})
-	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), MappedStackFrame{}, nil
+	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), MappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
 }
 
 func TestProcess(t *testing.T) {
@@ -54,7 +54,7 @@ func TestProcess(t *testing.T) {
 		AssertOutput            func(td ptrace.Traces)
 	}{
 		{
-			Name: "attributes provided",
+			Name: "symbolicated stacktrace attribute provided",
 			ApplyAttributes: func(span ptrace.Span) {
 				span.Attributes().PutEmpty(cfg.ColumnsAttributeKey).SetEmptySlice().AppendEmpty().SetInt(42)
 				span.Attributes().PutEmpty(cfg.LinesAttributeKey).SetEmptySlice().AppendEmpty().SetInt(42)
@@ -70,13 +70,106 @@ func TestProcess(t *testing.T) {
 				rs := td.ResourceSpans().At(0)
 				ils := rs.ScopeSpans().At(0)
 				span := ils.Spans().At(0)
+
 				attr, ok := span.Attributes().Get(cfg.OutputStackTraceKey)
 				assert.True(t, ok)
 				assert.Equal(t, "symbolicated 42:42 function url", attr.Str())
+
+				attr, ok = span.Attributes().Get(cfg.ColumnsAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[42]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.LinesAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[42]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.FunctionsAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[\"function\"]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.UrlsAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[\"url\"]", attr.AsString())
 			},
 		},
-		// Add unit tests to include attributes preserving stack trace
-		// Add unit test testing the preserveStackTrace option
+		{
+			Name: "original stacktrace attributes preserved when preserveStackTrace is true (default)",
+			ApplyAttributes: func(span ptrace.Span) {
+				span.Attributes().PutEmpty(cfg.ColumnsAttributeKey).SetEmptySlice().FromRaw([]any{1, 2, 3})
+				span.Attributes().PutEmpty(cfg.LinesAttributeKey).SetEmptySlice().FromRaw([]any{4, 5, 6})
+				span.Attributes().PutEmpty(cfg.FunctionsAttributeKey).SetEmptySlice().FromRaw([]any{"func1", "func2", "func3"})
+				span.Attributes().PutEmpty(cfg.UrlsAttributeKey).SetEmptySlice().FromRaw([]any{"url1", "url2", "url3"})
+				span.Attributes().PutEmpty(cfg.OutputStackTraceKey).SetStr("Error: test error\n    at func1 (url1:4:1)\n    at func2 (url2:5:2)\n    at func3 (url3:6:3)")
+			},
+			AssertSymbolicatorCalls: func(s *testSymbolicator) {
+				assert.ElementsMatch(t, s.SymbolicatedLines, []symbolicatedLine{
+					{Line: 4, Column: 1, Function: "func1", URL: "url1"},
+					{Line: 5, Column: 2, Function: "func2", URL: "url2"},
+					{Line: 6, Column: 3, Function: "func3", URL: "url3"},
+				})
+			},
+			AssertOutput: func(td ptrace.Traces) {
+				rs := td.ResourceSpans().At(0)
+				ils := rs.ScopeSpans().At(0)
+				span := ils.Spans().At(0)
+				attr, ok := span.Attributes().Get(cfg.OriginalColumnsAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[1,2,3]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.OriginalLinesAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[4,5,6]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.OriginalFunctionsAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[\"func1\",\"func2\",\"func3\"]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.OriginalUrlsAttributeKey)
+				assert.True(t, ok)
+				assert.Equal(t, "[\"url1\",\"url2\",\"url3\"]", attr.AsString())
+
+				attr, ok = span.Attributes().Get(cfg.OriginalStackTraceKey)
+				assert.True(t, ok)
+				assert.Equal(t, "Error: test error\n    at func1 (url1:4:1)\n    at func2 (url2:5:2)\n    at func3 (url3:6:3)", attr.AsString())
+			},
+		},
+		{
+			Name: "original stacktrace attributes not preserved when preserveStackTrace is false",
+			ApplyAttributes: func(span ptrace.Span) {
+				processor.cfg.PreserveStackTrace = false
+				span.Attributes().PutEmpty(cfg.ColumnsAttributeKey).SetEmptySlice().FromRaw([]any{1, 2, 3})
+				span.Attributes().PutEmpty(cfg.LinesAttributeKey).SetEmptySlice().FromRaw([]any{4, 5, 6})
+				span.Attributes().PutEmpty(cfg.FunctionsAttributeKey).SetEmptySlice().FromRaw([]any{"func1", "func2", "func3"})
+				span.Attributes().PutEmpty(cfg.UrlsAttributeKey).SetEmptySlice().FromRaw([]any{"url1", "url2", "url3"})
+				span.Attributes().PutEmpty(cfg.OutputStackTraceKey).SetStr("Error: test error\n    at func1 (url1:4:1)\n    at func2 (url2:5:2)\n    at func3 (url3:6:3)")
+			},
+			AssertSymbolicatorCalls: func(s *testSymbolicator) {
+				assert.ElementsMatch(t, s.SymbolicatedLines, []symbolicatedLine{
+					{Line: 4, Column: 1, Function: "func1", URL: "url1"},
+					{Line: 5, Column: 2, Function: "func2", URL: "url2"},
+					{Line: 6, Column: 3, Function: "func3", URL: "url3"},
+				})
+			},
+			AssertOutput: func(td ptrace.Traces) {
+				rs := td.ResourceSpans().At(0)
+				ils := rs.ScopeSpans().At(0)
+				span := ils.Spans().At(0)
+				_, ok := span.Attributes().Get(cfg.OriginalColumnsAttributeKey)
+				assert.False(t, ok)
+
+				_, ok = span.Attributes().Get(cfg.OriginalLinesAttributeKey)
+				assert.False(t, ok)
+
+				_, ok = span.Attributes().Get(cfg.OriginalFunctionsAttributeKey)
+				assert.False(t, ok)
+
+				_, ok = span.Attributes().Get(cfg.OriginalUrlsAttributeKey)
+				assert.False(t, ok)
+
+				_, ok = span.Attributes().Get(cfg.OriginalStackTraceKey)
+				assert.False(t, ok)
+			},
+		},
 		{
 			Name: "missing columns attribute",
 			ApplyAttributes: func(span ptrace.Span) {

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -26,14 +26,14 @@ func (ts *testSymbolicator) clear() {
 	ts.SymbolicatedLines = nil
 }
 
-func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (*MappedStackFrame, error) {
+func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (*mappedStackFrame, error) {
 	ts.SymbolicatedLines = append(ts.SymbolicatedLines, symbolicatedLine{
 		Line:     line,
 		Column:   column,
 		Function: function,
 		URL:      url,
 	})
-	return &MappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
+	return &mappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
 }
 
 func TestProcess(t *testing.T) {

--- a/processor/trace_processor_test.go
+++ b/processor/trace_processor_test.go
@@ -2,7 +2,6 @@ package symbolicatorprocessor
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,14 +26,14 @@ func (ts *testSymbolicator) clear() {
 	ts.SymbolicatedLines = nil
 }
 
-func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (string, *MappedStackFrame, error) {
+func (ts *testSymbolicator) symbolicate(ctx context.Context, line, column int64, function, url string) (*MappedStackFrame, error) {
 	ts.SymbolicatedLines = append(ts.SymbolicatedLines, symbolicatedLine{
 		Line:     line,
 		Column:   column,
 		Function: function,
 		URL:      url,
 	})
-	return fmt.Sprintf("symbolicated %d:%d %s %s", line, column, function, url), &MappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
+	return &MappedStackFrame{FunctionName: function, Col: column, Line: line, URL: url}, nil
 }
 
 func TestProcess(t *testing.T) {
@@ -73,7 +72,7 @@ func TestProcess(t *testing.T) {
 
 				attr, ok := span.Attributes().Get(cfg.OutputStackTraceKey)
 				assert.True(t, ok)
-				assert.Equal(t, "symbolicated 42:42 function url", attr.Str())
+				assert.Equal(t, "at function(url:42:42)", attr.Str())
 
 				attr, ok = span.Attributes().Get(cfg.ColumnsAttributeKey)
 				assert.True(t, ok)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

Replacing values in attributes that held lines, columns, function names, and urls information with their symbolicated counterparts. Original values are being preserved in other attributes.

## How to verify that this has the expected result

I tested locally. Running the collector with these changes and sending the output to honeycomb gave back this:

![image](https://github.com/user-attachments/assets/bbe89835-1232-4cb5-9748-f7772dce4f53)


