### PR TITLE
fix: Only use url path to resolve files

### DIFF
--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	neturl "net/url"
 
 	"github.com/honeycombio/symbolic-go"
 )
@@ -38,14 +37,8 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 		return &mappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
-	u, err := neturl.Parse(url)
-
-	if err != nil {
-		return nil, err
-	}
-
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
-	source, sMap, err := ns.store.GetSourceMap(ctx, u.Path)
+	source, sMap, err := ns.store.GetSourceMap(ctx, url)
 
 	if err != nil {
 		return &mappedStackFrame{}, err

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	neturl "net/url"
 
 	"github.com/honeycombio/symbolic-go"
 )
@@ -37,8 +38,14 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 		return &mappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
+	u, err := neturl.Parse(url)
+
+	if err != nil {
+		return nil, err
+	}
+
 	// TODO: we should look to see if we have already made a SourceMapCache for this URL
-	source, sMap, err := ns.store.GetSourceMap(ctx, url)
+	source, sMap, err := ns.store.GetSourceMap(ctx, u.Path)
 
 	if err != nil {
 		return &mappedStackFrame{}, err


### PR DESCRIPTION
## Which problem is this PR solving?

- Resolving the source map directive from the relative position of the source file
- Only using the path of the URL provided in the stack trace
