### PR TITLE
feat: Copy dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add libgcc libc6-compat
 
 COPY --from=build --chmod=755 /go/src/otelcol-dev/otelcol-dev /otelcol-dev
 COPY --from=build  /go/src/config.yaml /
-COPY --from=build /go/pkg/mod/github.com/honeycombio/symbolic-go@v0.0.2/lib/linux_aarch64/libsymbolic_cabi.so /go/pkg/mod/github.com/honeycombio/symbolic-go@v0.0.2/lib/linux_aarch64/
+COPY --from=build /go/pkg/mod/github.com/honeycombio/ /go/pkg/mod/github.com/honeycombio/
 
 ENTRYPOINT [ "/otelcol-dev" ]
 CMD [ "--config", "config.yaml" ]


### PR DESCRIPTION
## Which problem is this PR solving?

We previously had the version and architecture of the build specified in the Dockerfile. This removes this so that we can copy the required dependencies without worrying about version/arch
