### PR TITLE
feat: cache source map objects

### DIFF
--- a/processor/config.go
+++ b/processor/config.go
@@ -1,5 +1,7 @@
 package symbolicatorprocessor
 
+import "time"
+
 // Config defines configuration for the symbolicator processor.
 type Config struct {
 	// ColumnsAttributeKey is the attribute key that contains the column numbers
@@ -54,6 +56,9 @@ type Config struct {
 	// SourceMapFilePath is a file path to where the minified source and source
 	// maps are stored on disk.
 	SourceMapFilePath string `mapstructure:"source_map_file_path"`
+
+	// Timeout is the maximum time to wait for a response from the symbolicator.
+	Timeout time.Duration `mapstructure:"timeout"`
 }
 
 // Validate checks the configuration for any issues.

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -39,7 +39,7 @@ func createDefaultConfig() component.Config {
 func createTracesProcessor(ctx context.Context, set processor.Settings, cfg component.Config, next consumer.Traces) (processor.Traces, error) {
 	symCfg := cfg.(*Config)
 	fs := newFileStore(symCfg.SourceMapFilePath, set.Logger)
-	sym := newBasicSymbolicator(fs)
+	sym := newBasicSymbolicator(ctx, symCfg.Timeout, fs)
 	processor := newSymbolicatorProcessor(ctx, symCfg, set, sym)
 	return processorhelper.NewTraces(ctx, set, cfg, next, processor.processTraces, processorhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}))
 }

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -2,6 +2,7 @@ package symbolicatorprocessor
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -30,6 +31,7 @@ func createDefaultConfig() component.Config {
 		OriginalColumnsAttributeKey:   "exception.structured_stacktrace.columns.original",
 		OriginalUrlsAttributeKey:      "exception.structured_stacktrace.urls.original",
 		SourceMapFilePath:             ".",
+		Timeout:                       5 * time.Second,
 	}
 }
 

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/honeycombio/symbolic-go"
 )
@@ -13,11 +14,20 @@ type sourceMapStore interface {
 }
 
 type basicSymbolicator struct {
-	store sourceMapStore
+	store   sourceMapStore
+	timeout time.Duration
+	ch      chan struct{}
+	cache   map[string]*symbolic.SourceMapCache
 }
 
-func newBasicSymbolicator(store sourceMapStore) *basicSymbolicator {
-	return &basicSymbolicator{store: store}
+func newBasicSymbolicator(_ context.Context, timeout time.Duration, store sourceMapStore) *basicSymbolicator {
+	return &basicSymbolicator{
+		store:   store,
+		timeout: timeout,
+		// the channel is buffered to allow for a single request to be in progress at a time
+		ch:    make(chan struct{}, 1),
+		cache: map[string]*symbolic.SourceMapCache{},
+	}
 }
 
 type mappedStackFrame struct {
@@ -37,24 +47,7 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 		return &mappedStackFrame{}, fmt.Errorf("line must be uint32: %d", line)
 	}
 
-	// TODO: we should look to see if we have already made a SourceMapCache for this URL
-	source, sMap, err := ns.store.GetSourceMap(ctx, url)
-
-	if err != nil {
-		return &mappedStackFrame{}, err
-	}
-
-	// Create a new source map cache
-	// TODO: we should cache this but they are not thread safe
-	// so we need to lock around them
-	// TODO: we should also have a way to evict old source maps
-	smc, err := symbolic.NewSourceMapCache(source, sMap)
-
-	if err != nil {
-		return &mappedStackFrame{}, err
-	}
-
-	t, err := smc.Lookup(uint32(line), uint32(column), 0)
+	t, err := ns.limitedSymbolicate(ctx, line, column, url)
 
 	if err != nil {
 		return &mappedStackFrame{}, err
@@ -66,4 +59,37 @@ func (ns *basicSymbolicator) symbolicate(ctx context.Context, line, column int64
 		Line:         int64(t.Line),
 		Col:          int64(t.Col),
 	}, nil
+}
+
+// limitedSymbolicate performs the actual symbolication. It is limited to a single request at a time
+// it checks and caches the source map cache before loading the source map from the store
+func (ns *basicSymbolicator) limitedSymbolicate(ctx context.Context, line, column int64, url string) (*symbolic.SourceMapCacheToken, error) {
+	select {
+	case ns.ch <- struct{}{}:
+	case <-time.After(ns.timeout):
+		return nil, fmt.Errorf("timeout")
+	}
+
+	defer func() {
+		<-ns.ch
+	}()
+
+	smc, ok := ns.cache[url]
+
+	if !ok {
+		source, sMap, err := ns.store.GetSourceMap(ctx, url)
+
+		if err != nil {
+			return nil, err
+		}
+
+		smc, err = symbolic.NewSourceMapCache(source, sMap)
+		if err != nil {
+			return nil, err
+		}
+
+		ns.cache[url] = smc
+	}
+
+	return smc.Lookup(uint32(line), uint32(column), 0)
 }

--- a/processor/symbolicator_test.go
+++ b/processor/symbolicator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
@@ -13,7 +14,7 @@ func TestSymbolicator(t *testing.T) {
 	ctx := context.Background()
 
 	fs := newFileStore("../test_assets", zaptest.NewLogger(t))
-	sym := newBasicSymbolicator(fs)
+	sym := newBasicSymbolicator(ctx, 5*time.Second, fs)
 
 	sf, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
 	line := formatStackFrame(sf)


### PR DESCRIPTION
## Which problem is this PR solving?

We don't want/need to load and create the source map objects for every line. We can reuse them.

This adds a naive limiter around loading and using the source map cache objects.