### PR TITLE
fix: Update source map URL regex

### DIFF
--- a/processor/file_store.go
+++ b/processor/file_store.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	mappingURLRegex                  = regexp.MustCompile(`\/\/[#@]\s(source(?:Mapping)?URL)=\s*(\S+)`)
+	mappingURLRegex                  = regexp.MustCompile(`\/\/[#@]\s(sourceMappingURL)=\s*(\S+)`)
 	errFailedToFindSourceFile        = fmt.Errorf("failed to find source file")
 	errFailedToFindSourceMapLocation = fmt.Errorf("failed to find source map location")
 	errFailedToFindSourceMap         = fmt.Errorf("failed to find source map")


### PR DESCRIPTION
## Which problem is this PR solving?
We were seeing some issues with the regex also picking up `sourceURL` which caused some symbolication failures. Updated the regex to match only `sourceMappingURL`. Will write some tests for this with more realistic JS files in a future PR.

## How to verify that this has the expected result
Tests pass.