### PR TITLE
feat: Update for repo visibility change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,10 @@ jobs:
     docker:
       - image: cimg/go:1.22
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - SHA256:S/ROrHXpQH6H9irqoTBO/T6bKdv0TLepe2KjL5v32SM
       - checkout
       - run:
           name: Run unit tests
           command: make test
-          environment:
-            GOPRIVATE: github.com/honeycombio/symbolic-go
   publish_github:
     docker:
       - image: cibuilds/github:0.13.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,12 @@ FROM golang:1.23 AS build
 
 WORKDIR /go/src
 
-RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
-
 ADD ./processor ./processor
 ADD ./builder-config.yaml ./
 ADD ./Makefile ./
 ADD ./config.yaml ./
 
-ARG GOPRIVATE=github.com/honeycombio/symbolic-go
-RUN --mount=type=ssh make build
+RUN make build
 
 FROM gcr.io/distroless/cc
 

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ build: builder
 
 .PHONY: build-docker
 build-docker:
-	docker buildx build --ssh default . -t collector-symbolicator-processor 
+	docker buildx build -t collector-symbolicator-processor
 
-.PHONY: run 
+.PHONY: run
 run: build
 	go run ./otelcol-dev --config config.yaml
 


### PR DESCRIPTION
Removes the additional hoops that we jumped through to access the symbolic-go repo when it was private as it has now been made public.