### PR TITLE
fix: Provide path for docker build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: builder
 
 .PHONY: build-docker
 build-docker:
-	docker buildx build -t collector-symbolicator-processor
+	docker buildx build . -t collector-symbolicator-processor
 
 .PHONY: run
 run: build


### PR DESCRIPTION
I broke the build command in #19 by removing the path, add it back in