### PR TITLE
feat: Add a simple LRU cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,35 +82,30 @@ urls: ["https://example.com/static/dist/main.c383b093b0b66825a9c3.js","https://e
 
 ## Advanced Configuration
 
+### Attribute Mapping
+
 The following configuration options can also be provided to change the attributes used to look for stack traces and store them.
 
-```
-    processors:
-      symbolicator:
-        # Which attribute should the columns of the stack trace be sourced from
-        columns_attribute_key: exception.structured_stacktrace.columns
-        # Which attribute should the functions of the stack trace be sourced from
-        functions_attribute_key: exception.structured_stacktrace.functions
-        # Which attribute should the lines of the stack trace be sourced from
-        lines_attribute_key: exception.structured_stacktrace.lines
-        # Which attribute should the urls of the stack trace be sourced from
-        urls_attribute_key: exception.structured_stacktrace.urls
-        # Which attribute should the symbolicated stack trace be populated into
-        output_stack_trace_key: exception.stacktrace
-        # Which attribute contains the exception type
-        stack_type_key: exception.type
-        # Which attribute contains the exception message
-        stack_message_key: exception.message
-        # After the stack trace has been symbolicated should the original values be preserved as attributes
-        preserve_stack_trace: true
-        # If the stack trace is being preserved which key should it be copied to
-        original_stack_trace_key: exception.stacktrace.original
-        # If the stack trace is being preserved which key should the functions be copied to
-        original_columns_attribute_key: exception.structured_stacktrace.functions.original
-        # If the stack trace is being preserved which key should the lines be copied to
-        original_functions_attribute_key: exception.structured_stacktrace.lines.original
-        # If the stack trace is being preserved which key should the columns be copied to
-        original_lines_attribute_key: exception.structured_stacktrace.columns.original
-        # If the stack trace is being preserved which key should the urls be copied to
-        original_urls_attribute_key: exception.structured_stacktrace.urls.original
-```
+
+| Config Key                                | Description                                                                 | Example Value                                                      |
+|------------------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------------------|
+| `columns_attribute_key`            | Which attribute should the columns of the stack trace be sourced from       | `exception.structured_stacktrace.columns`                          |
+| `functions_attribute_key`          | Which attribute should the functions of the stack trace be sourced from     | `exception.structured_stacktrace.functions`                        |
+| `lines_attribute_key`              | Which attribute should the lines of the stack trace be sourced from         | `exception.structured_stacktrace.lines`                            |
+| `urls_attribute_key`               | Which attribute should the urls of the stack trace be sourced from          | `exception.structured_stacktrace.urls`                             |
+| `output_stack_trace_key`           | Which attribute should the symbolicated stack trace be populated into       | `exception.stacktrace`                                             |
+| `stack_type_key`                   | Which attribute contains the exception type                                 | `exception.type`                                                   |
+| `stack_message_key`                | Which attribute contains the exception message                              | `exception.message`                                                |
+| `preserve_stack_trace`             | After the stack trace has been symbolicated should the original values be preserved as attributes | `true`                                                             |
+| `original_stack_trace_key`         | If the stack trace is being preserved which key should it be copied to      | `exception.stacktrace.original`                                    |
+| `original_columns_attribute_key`   | If the stack trace is being preserved which key should the functions be copied to | `exception.structured_stacktrace.functions.original`               |
+| `original_functions_attribute_key` | If the stack trace is being preserved which key should the lines be copied to | `exception.structured_stacktrace.lines.original`                   |
+| `original_lines_attribute_key`     | If the stack trace is being preserved which key should the columns be copied to | `exception.structured_stacktrace.columns.original`                 |
+| `original_urls_attribute_key`      | If the stack trace is being preserved which key should the urls be copied to | `exception.structured_stacktrace.urls.original`                    |
+
+### Additional Options
+
+| Config Key                    | Description                                           | Example Value |
+|------------------------|-------------------------------------------------------|---------------|
+| `timeout`              | Max duration to wait to symbolicate a stack trace in seconds.     | `5`          |
+| `source_map_cache_size`   | The maximum number of source maps to cache. Reduce this if you are running into memory issues with the collector.          | `128`         |

--- a/processor/config.go
+++ b/processor/config.go
@@ -60,9 +60,12 @@ type Config struct {
 
 	// S3SourceMapConfiguration is the configuration for sourcing source maps from S3.
 	S3SourceMapConfiguration *S3SourceMapConfiguration `mapstructure:"s3_source_maps"`
-  
-  // Timeout is the maximum time to wait for a response from the symbolicator.
+
+	// Timeout is the maximum time to wait for a response from the symbolicator.
 	Timeout time.Duration `mapstructure:"timeout"`
+
+	// CacheSize is the maximum number of source maps to cache.
+	SourceMapCacheSize int `mapstructure:"source_map_cache_size"`
 }
 
 type LocalSourceMapConfiguration struct {

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -34,7 +34,8 @@ func createDefaultConfig() component.Config {
 		LocalSourceMapConfiguration: &LocalSourceMapConfiguration{
 			Path: ".",
 		},
-		Timeout: 5 * time.Second,
+		Timeout:            5 * time.Second,
+		SourceMapCacheSize: 128,
 	}
 }
 
@@ -54,7 +55,7 @@ func createTracesProcessor(ctx context.Context, set processor.Settings, cfg comp
 		}
 	}
 
-	sym, err := newBasicSymbolicator(ctx, symCfg.Timeout, store)
+	sym, err := newBasicSymbolicator(ctx, symCfg.Timeout, symCfg.SourceMapCacheSize, store)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -34,7 +34,7 @@ func createDefaultConfig() component.Config {
 		LocalSourceMapConfiguration: &LocalSourceMapConfiguration{
 			Path: ".",
 		},
-		Timeout:                       5 * time.Second,
+		Timeout: 5 * time.Second,
 	}
 }
 
@@ -54,7 +54,11 @@ func createTracesProcessor(ctx context.Context, set processor.Settings, cfg comp
 		}
 	}
 
-	sym := newBasicSymbolicator(ctx, symCfg.Timeout, store)
+	sym, err := newBasicSymbolicator(ctx, symCfg.Timeout, store)
+	if err != nil {
+		return nil, err
+	}
+
 	processor := newSymbolicatorProcessor(ctx, symCfg, set, sym)
 	return processorhelper.NewTraces(ctx, set, cfg, next, processor.processTraces, processorhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}))
 }

--- a/processor/go.mod
+++ b/processor/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/smithy-go v1.22.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/processor/go.sum
+++ b/processor/go.sum
@@ -48,6 +48,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
+github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/honeycombio/symbolic-go v0.0.2 h1:2IL4/USuSblJRQKWGU3vFwjIrf0j7UsMB18cKqz2KMk=
 github.com/honeycombio/symbolic-go v0.0.2/go.mod h1:DaiGCEp7qVz7cMaLtJ8lfSFl48MLJA6qJj4naJSsfCY=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/processor/symbolicator.go
+++ b/processor/symbolicator.go
@@ -21,8 +21,8 @@ type basicSymbolicator struct {
 	cache   *lru.Cache[string, *symbolic.SourceMapCache]
 }
 
-func newBasicSymbolicator(_ context.Context, timeout time.Duration, store sourceMapStore) (*basicSymbolicator, error) {
-	cache, err := lru.New[string, *symbolic.SourceMapCache](128) // Adjust the size as needed
+func newBasicSymbolicator(_ context.Context, timeout time.Duration, sourceMapCacheSize int, store sourceMapStore) (*basicSymbolicator, error) {
+	cache, err := lru.New[string, *symbolic.SourceMapCache](sourceMapCacheSize) // Adjust the size as needed
 
 	if err != nil {
 		return nil, err

--- a/processor/symbolicator_test.go
+++ b/processor/symbolicator_test.go
@@ -14,7 +14,7 @@ func TestSymbolicator(t *testing.T) {
 	ctx := context.Background()
 
 	fs := newFileStore(ctx, zaptest.NewLogger(t), &LocalSourceMapConfiguration{Path: "../test_assets"})
-	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, fs)
+	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, 128, fs)
 
 	sf, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
 	line := formatStackFrame(sf)
@@ -36,7 +36,7 @@ func TestSymbolicatorCache(t *testing.T) {
 	ctx := context.Background()
 
 	fs := newFileStore(ctx, zaptest.NewLogger(t), &LocalSourceMapConfiguration{Path: "../test_assets"})
-	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, fs)
+	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, 128, fs)
 
 	// Cache should be empty to start
 	assert.Equal(t, 0, sym.cache.Len())


### PR DESCRIPTION
## Which problem is this PR solving?
We were running into OOM issues because we were storing all the source maps without cleaning up. This PR adds a basic LRU cache so that we're limiting the amount of source maps we're caching.

## Short description of the changes
- Added [LRU cache](https://pkg.go.dev/github.com/hashicorp/golang-lru/v2#section-readme) package
- Replaced simple cache with LRU cache
- Added config object to modify size of LRU cache

## How to verify that this has the expected result
- Tests pass
