### PR TITLE
feat: Keep query params in url path

### DIFF
--- a/symbolicatorprocessor/store.go
+++ b/symbolicatorprocessor/store.go
@@ -106,9 +106,6 @@ func newS3Store(ctx context.Context, logger *zap.Logger, cfg *S3SourceMapConfigu
 
 	return &store{
 		fetch: func(ctx context.Context, key string) ([]byte, error) {
-			// S3 does not allow / character in key name
-			key = strings.TrimPrefix(key, "/")
-
 			result, err := client.GetObject(ctx, &s3.GetObjectInput{
 				Bucket: aws.String(cfg.BucketName),
 				Key:    aws.String(key),

--- a/symbolicatorprocessor/store.go
+++ b/symbolicatorprocessor/store.go
@@ -39,6 +39,10 @@ func (s *store) GetSourceMap(ctx context.Context, url string) ([]byte, []byte, e
 
 	path := filepath.Join(s.prefix, u.Path)
 
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+
 	source, err := s.fetch(ctx, path)
 
 	if err != nil {
@@ -102,6 +106,9 @@ func newS3Store(ctx context.Context, logger *zap.Logger, cfg *S3SourceMapConfigu
 
 	return &store{
 		fetch: func(ctx context.Context, key string) ([]byte, error) {
+			// S3 does not allow / character in key name
+			key = strings.TrimPrefix(key, "/")
+
 			result, err := client.GetObject(ctx, &s3.GetObjectInput{
 				Bucket: aws.String(cfg.BucketName),
 				Key:    aws.String(key),

--- a/symbolicatorprocessor/store.go
+++ b/symbolicatorprocessor/store.go
@@ -106,6 +106,8 @@ func newS3Store(ctx context.Context, logger *zap.Logger, cfg *S3SourceMapConfigu
 
 	return &store{
 		fetch: func(ctx context.Context, key string) ([]byte, error) {
+			key = strings.TrimPrefix(key, "/")
+
 			result, err := client.GetObject(ctx, &s3.GetObjectInput{
 				Bucket: aws.String(cfg.BucketName),
 				Key:    aws.String(key),


### PR DESCRIPTION
## Which problem is this PR solving?

Source files and maps can be versioned by query string parameters. We verified that S3 accepts keys with query string parameters (example key name: `index.js?hash=abc123`). Our collector currently strips the query information from urls.

## Short description of the changes
Adding the query parameter information (if it exists) to the path.

## How to verify that this has the expected result
Tested locally. 

Set up a web app that sent the following stacktrace:
![image](https://github.com/user-attachments/assets/31aaa890-d44b-4eed-b253-4937e7a682bd)

Source file and map was stored in an S3 bucket:
![image](https://github.com/user-attachments/assets/907e454a-8e71-41c7-80c3-3d0bd7068d3a)

Ran a local instance of this collector that received the stacktrace and lookup'ed the source map and file in the S3 bucket. Collector exported the following symbolicated stacktrace:
![image](https://github.com/user-attachments/assets/64b0a7c3-7856-499d-94ad-479d5630b254)