### PR TITLE
feat: Remove path when looking for source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The default configuration will load the source(map) files (this must include bot
 
 Each line of the stack trace includes the URL of the file it originated from.
 Taking this as an example `https://example.com/static/dist/main.c383b093b0b66825a9c3.js`.
-The path is stripped off leaving us with `/static/dist/main.c383b093b0b66825a9c3.js`.
+The base file name is then found `main.c383b093b0b66825a9c3.js`.
 This path is joined with the configured path and then read from disk.
 
 ## S3 Store
@@ -61,7 +61,7 @@ You can also load the source(map) files (this must include both the JavaScript s
 
 Each line of the stack trace includes the URL of the file it originated from.
 Taking this as an example `https://example.com/static/dist/main.c383b093b0b66825a9c3.js`.
-The path is stripped off leaving us with `/static/dist/main.c383b093b0b66825a9c3.js`.
+The base file name is then found `main.c383b093b0b66825a9c3.js`.
 This path is joined with the prefix if provided and then used as the key to
 source from the bucket.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also load the source(map) files from a GCS bucket.
 
 Each line of the stack trace includes the URL of the file it originated from.
 Taking this as an example `https://example.com/static/dist/main.c383b093b0b66825a9c3.js`.
-The path is stripped off leaving us with `main.c383b093b0b66825a9c3.js`.
+The base file name is then found `main.c383b093b0b66825a9c3.js`.
 This path is joined with the prefix if provided and then used as the key to
 source from the bucket.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can also load the source(map) files from a GCS bucket.
 
 Each line of the stack trace includes the URL of the file it originated from.
 Taking this as an example `https://example.com/static/dist/main.c383b093b0b66825a9c3.js`.
-The path is stripped off leaving us with `/static/dist/main.c383b093b0b66825a9c3.js`.
+The path is stripped off leaving us with `main.c383b093b0b66825a9c3.js`.
 This path is joined with the prefix if provided and then used as the key to
 source from the bucket.
 

--- a/symbolicatorprocessor/store.go
+++ b/symbolicatorprocessor/store.go
@@ -37,7 +37,10 @@ func (s *store) GetSourceMap(ctx context.Context, url string) ([]byte, []byte, e
 		return nil, nil, err
 	}
 
-	path := filepath.Join(s.prefix, u.Path)
+	// strip the path from the url and use the base name eg.
+	// https://www.honeycomb.io/assets/js/basic-mapping.js -> basic-mapping.js
+	base := filepath.Base(u.Path)
+	path := filepath.Join(s.prefix, base)
 
 	if u.RawQuery != "" {
 		path += "?" + u.RawQuery

--- a/symbolicatorprocessor/store_test.go
+++ b/symbolicatorprocessor/store_test.go
@@ -14,12 +14,12 @@ func TestFileStore(t *testing.T) {
 	fs, err := newFileStore(ctx, zaptest.NewLogger(t), &LocalSourceMapConfiguration{Path: "../test_assets"})
 	assert.NoError(t, err)
 
-	source, sMap, err := fs.GetSourceMap(ctx, "basic-mapping.js")
+	source, sMap, err := fs.GetSourceMap(ctx, jsFile)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, source)
 	assert.NotEmpty(t, sMap)
 
-	source, sMap, err = fs.GetSourceMap(ctx, "does-not-exist.js")
+	source, sMap, err = fs.GetSourceMap(ctx, noFile)
 	assert.ErrorIs(t, err, errFailedToFindSourceFile)
 }

--- a/symbolicatorprocessor/symbolicator_test.go
+++ b/symbolicatorprocessor/symbolicator_test.go
@@ -10,6 +10,11 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+var (
+	jsFile = "https://www.honeycomb.io/assets/js/basic-mapping.js"
+	noFile = "https://www.honeycomb.io/assets/js/does-not-exist.js"
+)
+
 func TestSymbolicator(t *testing.T) {
 	ctx := context.Background()
 
@@ -17,19 +22,19 @@ func TestSymbolicator(t *testing.T) {
 	assert.NoError(t, err)
 	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, 128, fs)
 
-	sf, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
+	sf, err := sym.symbolicate(ctx, 0, 34, "b", jsFile)
 	line := formatStackFrame(sf)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "    at bar(basic-mapping-original.js:8:1)", line)
 
-	_, err = sym.symbolicate(ctx, 0, 34, "b", "does-not-exist.js")
+	_, err = sym.symbolicate(ctx, 0, 34, "b", noFile)
 	assert.Error(t, err)
 
-	_, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", "basic-mapping.js")
+	_, err = sym.symbolicate(ctx, math.MaxInt64, 34, "b", jsFile)
 	assert.Error(t, err)
 
-	_, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", "basic-mapping.js")
+	_, err = sym.symbolicate(ctx, 0, math.MaxInt64, "b", jsFile)
 	assert.Error(t, err)
 }
 
@@ -44,7 +49,7 @@ func TestSymbolicatorCache(t *testing.T) {
 	assert.Equal(t, 0, sym.cache.Len())
 
 	// First symbolication should add to cache
-	sf, err := sym.symbolicate(ctx, 0, 34, "b", "basic-mapping.js")
+	sf, err := sym.symbolicate(ctx, 0, 34, "b", jsFile)
 	line := formatStackFrame(sf)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Instead of having users upload files to a specific path dictated by the source URLs. We can strip this path and just use the filename with the prefix to simplify things