### PR TITLE
maint: Update golang version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.24.3
     steps:
       - checkout
       - run:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.3
+golang 1.24.3

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.24.3
 
 use (
 	./otelcol-dev

--- a/symbolicatorprocessor/go.mod
+++ b/symbolicatorprocessor/go.mod
@@ -2,7 +2,7 @@ module github.com/honeycombio/opentelemetry-collector-symbolicator/symbolicatorp
 
 go 1.22.0
 
-toolchain go1.22.3
+toolchain go1.24.3
 
 require (
 	cloud.google.com/go/storage v1.50.0


### PR DESCRIPTION
Updates our toolchain and build tools to use the latest version of golang. We don't depend on any newer features of go yet so leaving the `go` directive at its current value.