### PR TITLE
feat: add exception.type and exception.message attributes to metrickit crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,16 +166,18 @@ Any frames that refer to unknown binaries will be left as-is.
 
 The following configuration options can also be provided to change the attributes used to look for stack traces and store them.
 
-| Config Key                                   | Description                                                                                       | Example Value                                          |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `symbolicator_failure_attribute_key`         | Signals if the the symbolicator fails to fully symbolicate the stack trace                        | `exception.symbolicator.failed`                        |
-| `stack_trace_attribute_key`                  | Which attribute should the stack trace of a generic stacktrace log be sourced from                | `exception.stacktrace`                                 |
-| `original_stack_trace_key`                   | If the stack trace is being preserved, which key should it be copied to                           | `exception.stacktrace.original`                        |
-| `build_uuid_attribute_key`                   | Which attribute should the binary UUID of a generic stacktrace log be sourced from                | `app.debug.build_uuid`                                 |
-| `app_executable_attribute_key`               | Which attribute should the name of the app executable of a generic stacktrace log be sourced from | `app.bundle.executable`                                |
-| `metrickit_stack_trace_attribute_key`        | Which attribute should the json representation of a metrickit stacktrace log be sourced from      | `metrickit.diagnostic.crash.exception.stacktrace_json` |
-| `output_metrickit_stack_trace_attribute_key` | Which attribute should the symbolicated metrickit stack trace be populated into                   | `exception.stacktrace`                                 |
-| `preserve_stack_trace`                       | After the stack trace has been symbolicated should the original values be preserved as attributes | `true`                                                 |
+| Config Key                                         | Description                                                                                       | Example Value                                          |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `symbolicator_failure_attribute_key`               | Signals if the the symbolicator fails to fully symbolicate the stack trace                        | `exception.symbolicator.failed`                        |
+| `stack_trace_attribute_key`                        | Which attribute should the stack trace of a generic stacktrace log be sourced from                | `exception.stacktrace`                                 |
+| `original_stack_trace_key`                         | If the stack trace is being preserved, which key should it be copied to                           | `exception.stacktrace.original`                        |
+| `build_uuid_attribute_key`                         | Which attribute should the binary UUID of a generic stacktrace log be sourced from                | `app.debug.build_uuid`                                 |
+| `app_executable_attribute_key`                     | Which attribute should the name of the app executable of a generic stacktrace log be sourced from | `app.bundle.executable`                                |
+| `metrickit_stack_trace_attribute_key`              | Which attribute should the json representation of a metrickit stacktrace log be sourced from      | `metrickit.diagnostic.crash.exception.stacktrace_json` |
+| `output_metrickit_stack_trace_attribute_key`       | Which attribute should the symbolicated metrickit stack trace be populated into                   | `exception.stacktrace`                                 |
+| `output_metrickit_exception_type_attribute_key`    | Which attribute should the exception type be populated into                                       | `exception.type`.                                      |
+| `output_metrickit_exception_message_attribute_key` | Which attribute should the exception message be populated into                                    | `exception.message`.                                   |
+| `preserve_stack_trace`                             | After the stack trace has been symbolicated should the original values be preserved as attributes | `true`                                                 |
 
 
 #### Additional Options

--- a/dsymprocessor/CHANGELOG.md
+++ b/dsymprocessor/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dSYM Processor changelog
 
+## v0.0.3 [beta] - 2025/06/26
+- feat: add exception.type and exception.message attributes to metrickit crashes (#76) | @mustafahaddara
+
 ## v0.0.2 [beta] - 2025/06/25
 ### ✨ Features
 - feat: symbolicate generic stack traces (#73) | @mustafahaddara

--- a/dsymprocessor/config.go
+++ b/dsymprocessor/config.go
@@ -29,6 +29,14 @@ type Config struct {
 	// symbolicated metrickit stack trace.
 	OutputMetricKitStackTraceAttributeKey string `mapstructure:"output_metrickit_stack_trace_attribute_key"`
 
+	// OutputMetricKitStackTraceAttributeKey is the attribute key that contains the
+	// inferred  metrickit stack trace.
+	OutputMetricKitExceptionTypeAttributeKey string `mapstructure:"output_metrickit_exception_type_attribute_key"`
+
+	// OutputMetricKitStackTraceAttributeKey is the attribute key that contains the
+	// symbolicated metrickit stack trace.
+	OutputMetricKitExceptionMessageAttributeKey string `mapstructure:"output_metrickit_exception_message_attribute_key"`
+
 	// preserveStackTrace is a config option that determines whether to keep the
 	// original stack trace in the output.
 	PreserveStackTrace bool `mapstructure:"preserve_stack_trace"`

--- a/dsymprocessor/factory.go
+++ b/dsymprocessor/factory.go
@@ -17,15 +17,17 @@ var (
 // createDefaultConfig creates the default configuration for the processor.
 func createDefaultConfig() component.Config {
 	return &Config{
-		SymbolicatorFailureAttributeKey:       "exception.symbolicator.failed",
-		StackTraceAttributeKey:                "exception.stacktrace",
-		OriginalStackTraceKey:                 "exception.stacktrace.original",
-		AppExecutableAttributeKey:             "app.bundle.executable",
-		BuildUUIDAttributeKey:                 "app.debug.build_uuid",
-		MetricKitStackTraceAttributeKey:       "metrickit.diagnostic.crash.exception.stacktrace_json",
-		OutputMetricKitStackTraceAttributeKey: "exception.stacktrace",
-		PreserveStackTrace:                    true,
-		DSYMStoreKey:                          "file_store",
+		SymbolicatorFailureAttributeKey:             "exception.symbolicator.failed",
+		StackTraceAttributeKey:                      "exception.stacktrace",
+		OriginalStackTraceKey:                       "exception.stacktrace.original",
+		AppExecutableAttributeKey:                   "app.bundle.executable",
+		BuildUUIDAttributeKey:                       "app.debug.build_uuid",
+		MetricKitStackTraceAttributeKey:             "metrickit.diagnostic.crash.exception.stacktrace_json",
+		OutputMetricKitStackTraceAttributeKey:       "exception.stacktrace",
+		OutputMetricKitExceptionTypeAttributeKey:    "exception.type",
+		OutputMetricKitExceptionMessageAttributeKey: "exception.message",
+		PreserveStackTrace:                          true,
+		DSYMStoreKey:                                "file_store",
 		LocalDSYMConfiguration: &LocalDSYMConfiguration{
 			Path: ".",
 		},

--- a/dsymprocessor/logs_processor.go
+++ b/dsymprocessor/logs_processor.go
@@ -222,8 +222,6 @@ func (sp *symbolicatorProcessor) processMetricKitAttributes(ctx context.Context,
 	// set this true at the beginning. If we succeed, we'll hit the "set to false" call at the end of this function
 	attributes.PutBool(sp.cfg.SymbolicatorFailureAttributeKey, true)
 
-	sp.setMetricKitExceptionAttrs(ctx, attributes)
-
 	var ok bool
 	var metrickitStackTraceValue pcommon.Value
 
@@ -271,6 +269,10 @@ func (sp *symbolicatorProcessor) processMetricKitAttributes(ctx context.Context,
 
 	// everything was a success, we can overwrite the `true` we put in at the beginning
 	attributes.PutBool(sp.cfg.SymbolicatorFailureAttributeKey, false)
+
+	// and we need to set exception.type and exception.message to make this a semantically valid exception
+	sp.setMetricKitExceptionAttrs(ctx, attributes)
+
 	return nil
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Adds `exception.type` and `exception.message` attributes to metrickit crashes so they show up in our Errors UI

## Short description of the changes
Implements the precedence ordering described in https://github.com/honeycombio/honeycomb-opentelemetry-swift/pull/88

## How to verify that this has the expected result
- [x] manual tests passed
- [x] unit tests pass

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
