### PR TITLE
rel: dsym_processor:v0.0.5 proguard_processor:v0.0.2 symbolicator:v0.0.9

### DIFF
--- a/dsymprocessor/CHANGELOG.md
+++ b/dsymprocessor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dSYM Processor changelog
 
+## v0.0.5 [beta] - 2025/07/02
+### 🚧 Maintenance
+- maint(deps): bump the aws group across 2 directories with 1 update (#79)
+- maint(deps): bump the otel group across 3 directories with 5 updates (#81)
+- maint: Update symbolic-go (#83)
+
+
 ## v0.0.4 [beta] - 2025/06/27
 ### ✨ Features
 

--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Proguard Processor changelog
 
+## v0.0.2 [beta] - 2025/07/02
+### 🚧 Maintenance
+- maint: Update symbolic-go (#83)
+
 ## v0.0.1 [beta] - 2025/07/02
 ### ✨ Features
 

--- a/symbolicatorprocessor/CHANGELOG.md
+++ b/symbolicatorprocessor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Symbolicator Processor changelog
 
+## v0.0.9 [beta] - 2025/07/02
+### 🚧 Maintenance
+- maint(deps): bump the aws group across 2 directories with 1 update (#79)
+- maint(deps): bump the otel group across 3 directories with 5 updates (#81)
+- maint: Update symbolic-go (#83)
+
 ## v0.0.8 [beta] - 2025/06/27
 ### ✨ Features
 


### PR DESCRIPTION
Added entries for new maintenance releases in dSYM Processor (v0.0.5), Proguard Processor (v0.0.2), and Symbolicator Processor (v0.0.9). Updates include dependency bumps for aws and otel groups, and an update to symbolic-go.
