### PR TITLE
fix: remove extra `()` in formatters

### DIFF
--- a/dsymprocessor/CHANGELOG.md
+++ b/dsymprocessor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### 🐛 Fixes
+- fix: stack traces no longer have extra `()` characters (#88) | @mustafahaddara
+
 ### 🚧 Maintenance
 
 - chore: improve parity for symbolication failure across the 3 processors (#86) | @jairo-mendoza

--- a/dsymprocessor/logs_processor.go
+++ b/dsymprocessor/logs_processor.go
@@ -88,7 +88,7 @@ func (sp *symbolicatorProcessor) processResourceSpans(ctx context.Context, rl pl
 func formatStackFrames(prefix, binaryName string, offset uint64, frames []*mappedDSYMStackFrame) string {
 	lines := make([]string, len(frames))
 	for i, loc := range frames {
-		lines[i] = fmt.Sprintf("%s %s() (in %s) (%s:%d) + %d", prefix, loc.symbol, binaryName, loc.path, loc.line, offset)
+		lines[i] = fmt.Sprintf("%s %s (in %s) (%s:%d) + %d", prefix, loc.symbol, binaryName, loc.path, loc.line, offset)
 	}
 
 	return strings.Join(lines, "\n")
@@ -208,7 +208,7 @@ func isUUID(maybeUUID string) bool {
 func formatMetricKitStackFrames(frame MetricKitCallStackFrame, frames []*mappedDSYMStackFrame) string {
 	lines := make([]string, len(frames))
 	for i, loc := range frames {
-		lines[i] = fmt.Sprintf("%s\t\t\t0x%X %s() (%s:%d) + %d", frame.BinaryName, frame.OffsetIntoBinaryTextSegment, loc.symbol, loc.path, loc.line, loc.symAddr)
+		lines[i] = fmt.Sprintf("%s\t\t\t0x%X %s (%s:%d) + %d", frame.BinaryName, frame.OffsetIntoBinaryTextSegment, loc.symbol, loc.path, loc.line, loc.symAddr)
 	}
 
 	return strings.Join(lines, "\n")

--- a/dsymprocessor/logs_processor_test.go
+++ b/dsymprocessor/logs_processor_test.go
@@ -86,10 +86,10 @@ func TestProcessStackTrace(t *testing.T) {
 			expected := `0   CoreFoundation                      0x00000001835df228 7821F73C-378B-3A10-BE90-EF526B7DBA93 + 1155624
 1   libobjc.A.dylib                     0x0000000180a79abc objc_exception_throw + 88
 2   CoreFoundation                      0x00000001835e15fc 7821F73C-378B-3A10-BE90-EF526B7DBA93 + 1164796
-3   Chateaux Bufeaux                    0x00000001025a0758 main() (in Chateaux Bufeaux) (MyFile.swift:1) + 231256
-4   Chateaux Bufeaux                    0x00000001025a0834 main() (in Chateaux Bufeaux) (MyFile.swift:1) + 231476
-5   Chateaux Bufeaux                    0x000000010259f2ac main() (in Chateaux Bufeaux) (MyFile.swift:1) + 225964
-6   Chateaux Bufeaux                    0x0000000102577fd1 main() (in Chateaux Bufeaux) (MyFile.swift:1) + 65489
+3   Chateaux Bufeaux                    0x00000001025a0758 main (in Chateaux Bufeaux) (MyFile.swift:1) + 231256
+4   Chateaux Bufeaux                    0x00000001025a0834 main (in Chateaux Bufeaux) (MyFile.swift:1) + 231476
+5   Chateaux Bufeaux                    0x000000010259f2ac main (in Chateaux Bufeaux) (MyFile.swift:1) + 225964
+6   Chateaux Bufeaux                    0x0000000102577fd1 main (in Chateaux Bufeaux) (MyFile.swift:1) + 65489
 7   libswift_Concurrency.dylib          0x000000018f0a9241 DCB9E73A-92BA-3782-BC6D-3E1906622689 + 414273`
 
 			assert.Equal(t, expected, symbolicated.Str())
@@ -188,7 +188,7 @@ func TestProcessMetricKit(t *testing.T) {
 			assert.True(t, found)
 
 			expected := `dyld(189FE480-5D5B-3B89-9289-58BC88624420) +68312
-    Chateaux Bufeaux			0x18854 main() (MyFile.swift:1) + 1
+    Chateaux Bufeaux			0x18854 main (MyFile.swift:1) + 1
     SwiftUI(6527276E-A3D1-30FB-BA68-ACA33324D618) +933200
     SwiftUI(6527276E-A3D1-30FB-BA68-ACA33324D618) +933484`
 

--- a/dsymprocessor/symbolicator_test.go
+++ b/dsymprocessor/symbolicator_test.go
@@ -25,7 +25,7 @@ func TestDSYMSymbolicator(t *testing.T) {
 	line := formatMetricKitStackFrames(baseFrame, sf)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "chateaux-bufeaux			0x18854 main() (/Users/mustafa/hny/chateaux-bufeaux-ios/Chateaux Bufeaux/Chateaux_BufeauxApp.swift:0) + 100372", line)
+	assert.Equal(t, "chateaux-bufeaux			0x18854 main (/Users/mustafa/hny/chateaux-bufeaux-ios/Chateaux Bufeaux/Chateaux_BufeauxApp.swift:0) + 100372", line)
 
 	// UUID doesn't exist
 	_, err = sym.symbolicateFrame(ctx, "2DBDCA05-2BAA-3BFE-9EF3-15A157D84058", "Chateaux Bufeaux", baseFrame.OffsetIntoBinaryTextSegment)
@@ -60,7 +60,7 @@ func TestDSYMSymbolicatorCache(t *testing.T) {
 	line := formatMetricKitStackFrames(baseFrame, sf)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "chateaux-bufeaux			0x18854 main() (/Users/mustafa/hny/chateaux-bufeaux-ios/Chateaux Bufeaux/Chateaux_BufeauxApp.swift:0) + 100372", line)
+	assert.Equal(t, "chateaux-bufeaux			0x18854 main (/Users/mustafa/hny/chateaux-bufeaux-ios/Chateaux Bufeaux/Chateaux_BufeauxApp.swift:0) + 100372", line)
 
 	// Cache should have one entry
 	assert.Equal(t, 1, sym.cache.Len())


### PR DESCRIPTION
## Which problem is this PR solving?
We were getting extra `()` characters in stack traces, particularly for stacks that included calls from anonymously defined lambdas and such

## Short description of the changes
Remove the `()` characters

## How to verify that this has the expected result
- [x] tests pass

---

- [x] CHANGELOG is updated
- [ ] ~~README is updated with documentation~~ N/A
