### PR TITLE
feat: add exception type & message to outputted android stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ The following configuration options can also be provided to change the attribute
 | `methods_attribute_key`              | Which attribute should the methods of the stack trace be sourced from                             | `exception.structured_stacktrace.methods`.           |
 | `lines_attribute_key`                | Which attribute should the lines of the stack trace be sourced from                               | `exception.structured_stacktrace.lines`              |
 | `output_stack_trace_key`             | Which attribute should the symbolicated stack trace be populated into                             | `exception.stacktrace`                               |
+| `exception_type_attribute_key`       | Which attribute should the exception type be sourced from                                         | `exception.type`                                     |
+| `exception_message_attribute_key`    | Which attribute should the exception message be sourced from                                      | `exception.message`                                  |
 | `preserve_stack_trace`               | After the stack trace has been symbolicated should the original values be preserved as attributes | `true`                                               |
 | `original_classes_attribute_key`     | If the stack trace is being preserved which key should the classes be copied to                   | `exception.structured_stacktrace.classes.original`   |
 | `original_methods_attribute_key`     | If the stack trace is being preserved which key should the methods be copied to                   | `exception.structured_stacktrace.methods.original`   |

--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: add exception type and message to outputted stacktraces
+
 ## v0.0.3 [beta] - 2025/07/24
 
 ### 🚧 Maintenance

--- a/proguardprocessor/config.go
+++ b/proguardprocessor/config.go
@@ -23,6 +23,12 @@ type Config struct {
 	// will be written to.
 	OutputStackTraceKey string `mapstructure:"output_stack_trace_key"`
 
+	// ExceptionTypeKey is the attribute key that contains the type of the exception.
+	ExceptionTypeKey string `mapstructure:"exception_type_key"`
+
+	// ExceptionMessageKey is the attribute key that contains the message of the exception.
+	ExceptionMessageKey string `mapstructure:"exception_message_key"`
+
 	// preserveStackTrace is a config option that determines whether to keep the
 	// original stack trace in the output.
 	PreserveStackTrace bool `mapstructure:"preserve_stack_trace"`

--- a/proguardprocessor/config.go
+++ b/proguardprocessor/config.go
@@ -23,11 +23,11 @@ type Config struct {
 	// will be written to.
 	OutputStackTraceKey string `mapstructure:"output_stack_trace_key"`
 
-	// ExceptionTypeKey is the attribute key that contains the type of the exception.
-	ExceptionTypeKey string `mapstructure:"exception_type_key"`
+	// ExceptionTypeAttributeKey is the attribute key that contains the type of the exception.
+	ExceptionTypeAttributeKey string `mapstructure:"exception_type_attribute_key"`
 
-	// ExceptionMessageKey is the attribute key that contains the message of the exception.
-	ExceptionMessageKey string `mapstructure:"exception_message_key"`
+	// ExceptionMessageAttributeKey is the attribute key that contains the message of the exception.
+	ExceptionMessageAttributeKey string `mapstructure:"exception_message_attribute_key"`
 
 	// preserveStackTrace is a config option that determines whether to keep the
 	// original stack trace in the output.

--- a/proguardprocessor/factory.go
+++ b/proguardprocessor/factory.go
@@ -19,17 +19,17 @@ var (
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		ClassesAttributeKey:         "exception.structured_stacktrace.classes",
-		MethodsAttributeKey:         "exception.structured_stacktrace.methods",
-		LinesAttributeKey:           "exception.structured_stacktrace.lines",
-		ExceptionTypeKey:            "exception.type",
-		ExceptionMessageKey:         "exception.message",
-		PreserveStackTrace:          true,
-		OriginalClassesAttributeKey: "exception.structured_stacktrace.classes.original",
-		OriginalMethodsAttributeKey: "exception.structured_stacktrace.methods.original",
-		OriginalLinesAttributeKey:   "exception.structured_stacktrace.lines.original",
-		ProguardUUIDAttributeKey:    "app.debug.proguard_uuid",
-		ProguardStoreKey:            "file_store",
+		ClassesAttributeKey:          "exception.structured_stacktrace.classes",
+		MethodsAttributeKey:          "exception.structured_stacktrace.methods",
+		LinesAttributeKey:            "exception.structured_stacktrace.lines",
+		ExceptionTypeAttributeKey:    "exception.type",
+		ExceptionMessageAttributeKey: "exception.message",
+		PreserveStackTrace:           true,
+		OriginalClassesAttributeKey:  "exception.structured_stacktrace.classes.original",
+		OriginalMethodsAttributeKey:  "exception.structured_stacktrace.methods.original",
+		OriginalLinesAttributeKey:    "exception.structured_stacktrace.lines.original",
+		ProguardUUIDAttributeKey:     "app.debug.proguard_uuid",
+		ProguardStoreKey:             "file_store",
 		LocalProguardConfiguration: &LocalStoreConfiguration{
 			Path: ".",
 		},

--- a/proguardprocessor/factory.go
+++ b/proguardprocessor/factory.go
@@ -22,6 +22,8 @@ func createDefaultConfig() component.Config {
 		ClassesAttributeKey:         "exception.structured_stacktrace.classes",
 		MethodsAttributeKey:         "exception.structured_stacktrace.methods",
 		LinesAttributeKey:           "exception.structured_stacktrace.lines",
+		ExceptionTypeKey:            "exception.type",
+		ExceptionMessageKey:         "exception.message",
 		PreserveStackTrace:          true,
 		OriginalClassesAttributeKey: "exception.structured_stacktrace.classes.original",
 		OriginalMethodsAttributeKey: "exception.structured_stacktrace.methods.original",

--- a/proguardprocessor/log_processor.go
+++ b/proguardprocessor/log_processor.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	errMissingAttribute = errors.New("missing attribute")
-	errMismatchedLength = errors.New("mismatched stacktrace attribute lengths")
+	errMissingAttribute     = errors.New("missing attribute")
+	errMismatchedLength     = errors.New("mismatched stacktrace attribute lengths")
 	errPartialSymbolication = errors.New("symbolication failed for some stack frames")
 )
 
@@ -138,10 +138,12 @@ func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attri
 
 	var symbolicationFailed bool
 
-	var exceptionType, _ = attributes.Get(p.cfg.ExceptionTypeKey)
-	var exceptionMessage, _ = attributes.Get(p.cfg.ExceptionMessageKey)
+	var exceptionType, hasExceptionType = attributes.Get(p.cfg.ExceptionTypeAttributeKey)
+	var exceptionMessage, hasExceptionMessage = attributes.Get(p.cfg.ExceptionMessageAttributeKey)
 
-	stack = append(stack, fmt.Sprintf("%s: %s", exceptionType.Str(), exceptionMessage.Str()))
+	if hasExceptionType && hasExceptionMessage {
+		stack = append(stack, fmt.Sprintf("%s: %s", exceptionType.Str(), exceptionMessage.Str()))
+	}
 
 	for i := 0; i < classes.Len(); i++ {
 		line := lines.At(i).Int()


### PR DESCRIPTION
## Short description of the changes
Based on #10

We were missing exception type & message so android stacktraces were looking like this:
<img width="1996" height="846" alt="image" src="https://github.com/user-attachments/assets/7f599bb2-4af2-409b-a2b3-71bdd5a12f55" />

Updating to make stack traces look like this (symbolication errors are now tabbed too):
<img width="2064" height="846" alt="image" src="https://github.com/user-attachments/assets/ec57e0e7-79b1-4f97-90b7-283af926fbd1" />


## How to verify that this has the expected result
Tests pass!

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
