### PR TITLE
chore: allow special negative line number in proguard processor

### DIFF
--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- chore: allow special negative line number in proguard processor (#102) | @jairo-mendoza
 - fix: fix processor not partial symbolicating stacktraces (#101) | @jairo-mendoza
 - feat: add exception type and message to outputted stacktraces (#99) | @jairo-mendoza
 

--- a/proguardprocessor/log_processor.go
+++ b/proguardprocessor/log_processor.go
@@ -136,7 +136,8 @@ func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attri
 	for i := 0; i < classes.Len(); i++ {
 		line := lines.At(i).Int()
 
-		if line < 0 || line > math.MaxUint32 {
+		// -2 is a special value line number indicating a native method per the android docs
+		if (line < 0 && line != -2) || line > math.MaxUint32 {
 			stack = append(stack, fmt.Sprintf("\tInvalid line number %d for %s.%s", line, classes.At(i).Str(), methods.At(i).Str()))
 			symbolicationFailed = true
 			continue


### PR DESCRIPTION
## Short description of the changes
We were seeing partially symbolicated stacktraces because Android stacktraces have a negative line number with a special meaning. According to the [android docs](https://developer.android.com/reference/kotlin/java/lang/StackTraceElement#stacktraceelement_1), a line number with a "value of -2 indicates that the method containing the execution point is a native method."

Before:
<img width="2776" height="1196" alt="image" src="https://github.com/user-attachments/assets/8f7f85c4-378a-4f5b-a3a9-b3528fdc2fd7" />

After:
<img width="1388" height="554" alt="Screenshot 2025-08-20 at 7 47 11 AM" src="https://github.com/user-attachments/assets/8aa7afd7-1644-4575-b082-67dea6f7c6bc" />

## How to verify that this has the expected result
Tested locally, tests still pass!

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
