### PR TITLE
fix: capitalization in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Collector Symbolicator Processor
 
-An open telemetry collector processor that will symbolicate JavaScript stack traces using source maps. This is compatible with [v0.12.0](https://github.com/honeycombio/honeycomb-opentelemetry-web/releases/tag/honeycomb-opentelemetry-web-v0.12.0) and onwards of the Honeycomb OpenTelemetry web SDK.
+An OpenTelemetry collector processor that will symbolicate JavaScript stack traces using source maps. This is compatible with [v0.12.0](https://github.com/honeycombio/honeycomb-opentelemetry-web/releases/tag/honeycomb-opentelemetry-web-v0.12.0) and onwards of the Honeycomb OpenTelemetry web SDK.
 
 To install this processor, include it in the build config file of your OpenTelemetry collector distro. You can also use the pre-built [Honeycomb OpenTelemetry collector distro](https://github.com/honeycombio/honeycomb-collector-distro) that already includes this processor.
 


### PR DESCRIPTION
fix casing in README

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #<enter issue here>

## Short description of the changes

## How to verify that this has the expected result

---

- [ ] CHANGELOG is updated
- [ ] README is updated with documentation
