### PR TITLE
rel: prepare for sourcemapprocessor release 0.0.12

### DIFF
--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.0.12 [beta] - 2025/10/22
+
 - feat: if `app.debug.source_map_uuid` is in the resource attributes, include it in source paths (#113) | @beekhc
 
 ## v0.0.11 [beta] - 2025/10/21

--- a/sourcemapprocessor/factory.go
+++ b/sourcemapprocessor/factory.go
@@ -17,7 +17,7 @@ var (
 )
 
 const (
-	processorVersion = "0.0.11"
+	processorVersion = "0.0.12"
 )
 
 // createDefaultConfig creates the default configuration for the processor.

--- a/sourcemapprocessor/generated_component_test.go
+++ b/sourcemapprocessor/generated_component_test.go
@@ -63,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
 			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(typ), cfg)
 			require.NoError(t, err)
-			host := componenttest.NewNopHost()
+			host := newMdatagenNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
 			require.NotPanics(t, func() {
@@ -134,4 +134,20 @@ func generateLifecycleTestTraces() ptrace.Traces {
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(-1 * time.Second)))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	return traces
+}
+
+var _ component.Host = (*mdatagenNopHost)(nil)
+
+type mdatagenNopHost struct{}
+
+func newMdatagenNopHost() component.Host {
+	return &mdatagenNopHost{}
+}
+
+func (mnh *mdatagenNopHost) GetExtensions() map[component.ID]component.Component {
+	return nil
+}
+
+func (mnh *mdatagenNopHost) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+	return nil
 }

--- a/sourcemapprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/sourcemapprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
+	"github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor/internal/metadata"
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 

--- a/sourcemapprocessor/metadata.yaml
+++ b/sourcemapprocessor/metadata.yaml
@@ -17,13 +17,18 @@ resource_attributes:
 telemetry:
   # metrics about internal performance of the symbolicator processor
   metrics:
-    processor_total_processed_frames:
+    processor_source_map_cache_size:
       enabled: true
-      description: Total number of frames the symbolicator processed.
-      unit: "1"
-      sum:
+      description: Size of the source map cache in bytes.
+      unit: "{sourcemaps}"
+      gauge:
         value_type: int
-        monotonic: true
+    processor_symbolication_duration:
+      enabled: true
+      description: Duration in seconds taken to symbolicate frames.
+      unit: s
+      histogram:
+        value_type: double
     processor_total_failed_frames:
       enabled: true
       description: Total number of frames the symbolicator failed to symbolicate.
@@ -31,12 +36,13 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-    processor_symbolication_duration:
+    processor_total_processed_frames:
       enabled: true
-      description: Duration in seconds taken to symbolicate frames.
-      unit: s
-      histogram:
-        value_type: double
+      description: Total number of frames the symbolicator processed.
+      unit: "1"
+      sum:
+        value_type: int
+        monotonic: true
     processor_total_source_map_fetch_failures:
       enabled: true
       description: Total number of source map fetch failures.
@@ -44,9 +50,3 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-    processor_source_map_cache_size:
-      enabled: true
-      description: Size of the source map cache in bytes.
-      unit: "{sourcemaps}"
-      gauge:
-        value_type: int


### PR DESCRIPTION
Prepare for sourcemapprocessor release 0.0.12

---

[X] Update `processorVersion` in `sourcemapprocessor/factory.go` to the upcoming release
[X] Run `mdatagen` as described in `DEVELOPING.md` to ensure autogenerated docs/classes are up to date
[X] Update relevant `CHANGELOG.md` files in each processor directory with the changes since the last release.
