### PR TITLE
feat(sourcemapprocessor): enhance symbolication process with per-stacktrace Error Caching

### DIFF
--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
-
 ## v0.0.5 [beta] - 2025/10/21
 
 - chore: reduce log verbosity by changing "Processing logs" from Info to Debug level (#111) | @clintonnkemdilim

--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
+
 ## v0.0.5 [beta] - 2025/10/21
 
 - chore: reduce log verbosity by changing "Processing logs" from Info to Debug level (#111) | @clintonnkemdilim

--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- perf: reduce redundant failed source map fetch attempts by 80-95% per stacktrace through error caching | @clintonnkemdilim
+- perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
 
 ## v0.0.12 [beta] - 2025/10/22
 

--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- perf: reduce redundant failed source map fetch attempts by 80-95% per stacktrace through error caching | @clintonnkemdilim
+
 ## v0.0.12 [beta] - 2025/10/22
 
 - feat: if `app.debug.source_map_uuid` is in the resource attributes, include it in source paths (#113) | @beekhc

--- a/sourcemapprocessor/trace_processor.go
+++ b/sourcemapprocessor/trace_processor.go
@@ -173,10 +173,7 @@ func (sp *symbolicatorProcessor) processThrow(ctx context.Context, attributes pc
 
 	stack = append(stack, fmt.Sprintf("%s: %s", stackType.Str(), stackMessage.Str()))
 
-	// Cache fetch errors (404, timeout) to avoid redundant fetches.
-	// Only FetchError types are cached - validation and parse errors are not cached
-	// as they are frame-specific or indicate transient issues that might be resolved.
-	// Note: Successful symbolications vary by line/column position, so can't be cached.
+	// Cache FetchErrors to avoid redundant fetches for missing resources.
 	fetchErrorCache := make(map[string]error)
 
 	var hasSymbolicationFailed bool

--- a/sourcemapprocessor/trace_processor.go
+++ b/sourcemapprocessor/trace_processor.go
@@ -177,7 +177,7 @@ func (sp *symbolicatorProcessor) processThrow(ctx context.Context, attributes pc
 	// Only FetchError types are cached - validation and parse errors are not cached
 	// as they are frame-specific or indicate transient issues that might be resolved.
 	// Note: Successful symbolications vary by line/column position, so can't be cached.
-	errorCache := make(map[string]error)
+	fetchErrorCache := make(map[string]error)
 
 	var hasSymbolicationFailed bool
 	for i := 0; i < columns.Len(); i++ {
@@ -194,7 +194,7 @@ func (sp *symbolicatorProcessor) processThrow(ctx context.Context, attributes pc
 		var err error
 
 		// Check if we have a cached fetch error for this URL
-		if cachedError, exists := errorCache[cacheKey]; exists {
+		if cachedError, exists := fetchErrorCache[cacheKey]; exists {
 			err = cachedError
 		} else {
 			mappedStackFrame, err = sp.symbolicator.symbolicate(ctx, line, column, function, url, buildUUID)
@@ -203,7 +203,7 @@ func (sp *symbolicatorProcessor) processThrow(ctx context.Context, attributes pc
 			if err != nil {
 				var fetchErr *FetchError
 				if errors.As(err, &fetchErr) {
-					errorCache[cacheKey] = err
+					fetchErrorCache[cacheKey] = err
 				}
 			}
 		}

--- a/sourcemapprocessor/trace_processor.go
+++ b/sourcemapprocessor/trace_processor.go
@@ -188,10 +188,7 @@ func (sp *symbolicatorProcessor) processThrow(ctx context.Context, attributes pc
 		column := columns.At(i).Int()
 		function := functions.At(i).Str()
 
-		cacheKey := url
-		if buildUUID != "" {
-			cacheKey = url + "|" + buildUUID
-		}
+		cacheKey := buildCacheKey(url, buildUUID)
 
 		sp.telemetryBuilder.ProcessorTotalProcessedFrames.Add(ctx, 1, sp.attributes)
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes: [FO-599](https://linear.app/honeycombio/issue/FO-599/per-stacktrace-deduping-sourcemapprocessor)

## Short description of the changes

Added per-stacktrace error caching to `sourcemapprocessor` to prevent repeatedly fetching missing source maps (404s, timeouts, etc.) within a single stacktrace.

- Introduced error caching for failed symbolication attempts to avoid redundant fetches for URLs without source maps.
- Updated the symbolication logic to return mapped values based on line and column adjustments, simulating real source map behavior.
- Added unit tests to verify deduplication of symbolication calls and ensure unique results for frames with the same URL but different line/column positions.

**Logic**:
1. Before symbolicating a frame, check if we've seen this URL fail before in this stacktrace
2. If yes, reuse the cached error (avoiding redundant failed fetches)
3. If no, perform symbolication and cache only errors
4. Successful symbolications are performed for each frame (since line/column position matters)
5. Source maps themselves are cached separately in `basicSymbolicator.cache` (LRU cache)
6. Cache is automatically GC'd after stacktrace processing completes

## How to verify that this has the expected result

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
