### PR TITLE
feat(proguardprocessor): implement error caching for symbolication process

### DIFF
--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚀 Performance
+
+- perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
+
 ## v0.0.5 [beta] - 2025/10/21
 
 - chore: reduce log verbosity by changing "Processing logs" from Info to Debug level (#111) | @clintonnkemdilim

--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-### 🚀 Performance
-
 - perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
 
 ## v0.0.5 [beta] - 2025/10/21


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes: [FO-624](https://linear.app/honeycombio/issue/FO-624/per-stacktrace-deduping-proguardprocessor)

## Short description of the changes

- Enhanced the symbolication process to cache FetchErrors, reducing redundant fetches for missing ProGuard mappings.
- Added tests to validate the caching mechanism and ensure performance improvements.
- Updated CHANGELOG to reflect the new performance enhancement.

See sourceprocessor ticket: [PR-116](https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/116)

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
