### PR TITLE
fix: Fix unhandled exceptions failing to retrieve Proguard UUID

### DIFF
--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Fix Proguard processor failing to retrieve Proguard UUID (#120) | @jairo-mendoza
 - perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
 
 ## v0.0.5 [beta] - 2025/10/21

--- a/proguardprocessor/log_processor.go
+++ b/proguardprocessor/log_processor.go
@@ -123,9 +123,9 @@ func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attri
 	}
 
 	// Support retrieving the Proguard UUID from either resource or log attributes, for now.
-	uuidValue, ok := resourceAttrs.Get(p.cfg.ProguardUUIDAttributeKey)
+	uuidValue, ok := attributes.Get(p.cfg.ProguardUUIDAttributeKey)
 	if !ok {
-		uuidValue, ok = attributes.Get(p.cfg.ProguardUUIDAttributeKey)
+		uuidValue, ok = resourceAttrs.Get(p.cfg.ProguardUUIDAttributeKey)
 		if !ok {
 			return fmt.Errorf("%w: %s", errMissingAttribute, p.cfg.ProguardUUIDAttributeKey)
 		}

--- a/proguardprocessor/log_processor.go
+++ b/proguardprocessor/log_processor.go
@@ -51,27 +51,28 @@ func (p *proguardLogsProcessor) ProcessLogs(ctx context.Context, logs plog.Logs)
 }
 
 func (p *proguardLogsProcessor) processResourceLogs(ctx context.Context, rl plog.ResourceLogs) {
+	resourceAttrs := rl.Resource().Attributes()
 	for j := 0; j < rl.ScopeLogs().Len(); j++ {
 		sl := rl.ScopeLogs().At(j)
-		p.processScopeLogs(ctx, sl)
+		p.processScopeLogs(ctx, sl, resourceAttrs)
 	}
 }
 
-func (p *proguardLogsProcessor) processScopeLogs(ctx context.Context, sl plog.ScopeLogs) {
+func (p *proguardLogsProcessor) processScopeLogs(ctx context.Context, sl plog.ScopeLogs, resourceAttrs pcommon.Map) {
 	for k := 0; k < sl.LogRecords().Len(); k++ {
 		lr := sl.LogRecords().At(k)
-		p.processLogRecord(ctx, lr)
+		p.processLogRecord(ctx, lr, resourceAttrs)
 	}
 }
 
-func (p *proguardLogsProcessor) processLogRecord(ctx context.Context, lr plog.LogRecord) {
+func (p *proguardLogsProcessor) processLogRecord(ctx context.Context, lr plog.LogRecord, resourceAttrs pcommon.Map) {
 	attributes := lr.Attributes()
 
 	// Add processor type and version as attributes
 	attributes.PutStr("honeycomb.processor_type", typeStr.String())
 	attributes.PutStr("honeycomb.processor_version", processorVersion)
 
-	err := p.processLogRecordThrow(ctx, attributes)
+	err := p.processLogRecordThrow(ctx, attributes, resourceAttrs)
 
 	if err != nil {
 		attributes.PutBool(p.cfg.SymbolicatorFailureAttributeKey, true)
@@ -81,7 +82,7 @@ func (p *proguardLogsProcessor) processLogRecord(ctx context.Context, lr plog.Lo
 	}
 }
 
-func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attributes pcommon.Map) error {
+func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attributes pcommon.Map, resourceAttrs pcommon.Map) error {
 	var ok bool
 	var classes, methods, lines, sourceFiles pcommon.Slice
 
@@ -121,9 +122,13 @@ func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attri
 		}
 	}
 
-	uuidValue, ok := attributes.Get(p.cfg.ProguardUUIDAttributeKey)
+	// Support retrieving the Proguard UUID from either resource or log attributes, for now.
+	uuidValue, ok := resourceAttrs.Get(p.cfg.ProguardUUIDAttributeKey)
 	if !ok {
-		return fmt.Errorf("%w: %s", errMissingAttribute, p.cfg.ProguardUUIDAttributeKey)
+		uuidValue, ok = attributes.Get(p.cfg.ProguardUUIDAttributeKey)
+		if !ok {
+			return fmt.Errorf("%w: %s", errMissingAttribute, p.cfg.ProguardUUIDAttributeKey)
+		}
 	}
 
 	uuid := uuidValue.Str()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes
One of the reasons why unhandled exceptions weren't being symbolicated was because the required Proguard UUID could not be found. We were searching for the uuid in the regular attributes, which is wrong. The reason being that our Android SDK [attaches the UUID to the resource attributes](https://github.com/honeycombio/honeycomb-opentelemetry-android/blob/c4140dcdb573bb6b883ee02a697031b917e4b7cc/core/src/main/java/io/honeycomb/opentelemetry/android/Honeycomb.kt#L136-L138). Therefore, we should be looking through the log's resource attrbutes when searching for uuid's in the proguard processor.

## How to verify that this has the expected result
Tests were adjusted, should be passing.

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
