### PR TITLE
refactor: prevent running proguard processor on logs without exception attributes

### DIFF
--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- refactor: prevent running proguard processor on logs without exception attributes (#127) | @jairo-mendoza
 - feat: Preserve all stack lines in the proguard processor stack trace parser (#125) | @jairo-mendoza
 - feat: add parsing method attribute to the proguard processor (#124) | @jairo-mendoza
 - feat: Implement stack trace parser in the proguard processor (#118) | @jairo-mendoza


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

Follow up to #126 

## Short description of the changes
The sourcemap processor was setting symbolicator attributes (like `exception.symbolicator.failed`) on logs that did not include any exception attributes. Quitting from the processor early if no exception attributes are found.

Note: This change does make `StackTraceAttributeKey` (default value is `exception.stacktrace`) required. However, we are already heavily depending on it.

## How to verify that this has the expected result
Tests added and adjusted, should pass.

---

- [X] CHANGELOG is updated
- [ ] README is updated with documentation
