### PR TITLE
refactor: move telemetry in dsym processor to only symbolicated logs

### DIFF
--- a/dsymprocessor/CHANGELOG.md
+++ b/dsymprocessor/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- perf: enhance symbolication process with per stacktrace error caching | @clintonnkemdilim
+- refactor: move telemetry in dsym processor to only symbolicated logs (#128) | @jairo-mendoza
+- perf: enhance symbolication process with per stacktrace error caching (#119) | @clintonnkemdilim
 
 ## v0.0.8 [beta] - 2025/11/10
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

Follow up to #126 & #127

## Short description of the changes
**The dsym processor already had the logic preventing it from running on non-exception logs!** All we need to do is move the telemetry to only be set on logs that we try to symbolicate.

## How to verify that this has the expected result
Tests still pass.

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
