### PR TITLE
feat(proguard-processor): Add stack trace preservation to collector-parsed route and add original source files preservation to structured route

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The following configuration options can also be provided to change the attribute
 | `original_classes_attribute_key`     | If the stack trace is being preserved which key should the classes be copied to                   | `exception.structured_stacktrace.classes.original`   |
 | `original_methods_attribute_key`     | If the stack trace is being preserved which key should the methods be copied to                   | `exception.structured_stacktrace.methods.original`   |
 | `original_lines_attribute_key`       | If the stack trace is being preserved which key should the lines be copied to                     | `exception.structured_stacktrace.lines.original`     |
+| `original_source_files_attribute_key` | If the stack trace is being preserved which key should the source files be copied to                   | `exception.structured_stacktrace.source_files.original` |
 | `original_stack_trace_key`           | If the stack trace is being preserved which key should it be copied to                            | `exception.stacktrace.original`                      |
 | `proguard_uuid_attribute_key`        | Which resource attribute should the proguard UUID of a generic stacktrace log be sourced from     | `app.debug.proguard_uuid`                            |
 

--- a/proguardprocessor/CHANGELOG.md
+++ b/proguardprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(proguard-processor): Add stack trace preservation to collector-parsed route and add original source files preservation to structured route (#130) | @jairo-mendoza
+
 ## v0.0.7 [beta] - 2025/11/19
 
 ### ✨ Features

--- a/proguardprocessor/config.go
+++ b/proguardprocessor/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	// line numbers.
 	OriginalLinesAttributeKey string `mapstructure:"original_lines_attribute_key"`
 
+	// OriginalSourceFilesAttributeKey is the attribute key that preserves the original
+	// source file names.
+	OriginalSourceFilesAttributeKey string `mapstructure:"original_source_files_attribute_key"`
+
 	// OriginalStackTraceKey is the attribute key that preserves the original stack
 	// trace.
 	OriginalStackTraceKey string `mapstructure:"original_stack_trace_key"`

--- a/proguardprocessor/factory.go
+++ b/proguardprocessor/factory.go
@@ -39,6 +39,7 @@ func createDefaultConfig() component.Config {
 		OriginalClassesAttributeKey:           "exception.structured_stacktrace.classes.original",
 		OriginalMethodsAttributeKey:           "exception.structured_stacktrace.methods.original",
 		OriginalLinesAttributeKey:             "exception.structured_stacktrace.lines.original",
+		OriginalSourceFilesAttributeKey:       "exception.structured_stacktrace.source_files.original",
 		OriginalStackTraceKey:                 "exception.stacktrace.original",
 		ProguardUUIDAttributeKey:              "app.debug.proguard_uuid",
 		ProguardStoreKey:                      "file_store",

--- a/proguardprocessor/log_processor.go
+++ b/proguardprocessor/log_processor.go
@@ -164,6 +164,10 @@ func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attri
 	// Set up iteration based on whether we have a parsed stack trace or structured attributes
 	if parsedStackTrace != nil {
 		iterCount = len(parsedStackTrace.elements)
+
+		if p.cfg.PreserveStackTrace {
+			attributes.PutStr(p.cfg.OriginalStackTraceKey, rawStackTrace.Str())
+		}
 	} else {
 		iterCount = classes.Len()
 		mappedClasses = attributes.PutEmptySlice(p.cfg.ClassesAttributeKey)
@@ -184,10 +188,8 @@ func (p *proguardLogsProcessor) processLogRecordThrow(ctx context.Context, attri
 			classes.CopyTo(attributes.PutEmptySlice(p.cfg.OriginalClassesAttributeKey))
 			methods.CopyTo(attributes.PutEmptySlice(p.cfg.OriginalMethodsAttributeKey))
 			lines.CopyTo(attributes.PutEmptySlice(p.cfg.OriginalLinesAttributeKey))
-
-			if originalStackTrace, ok := attributes.Get(p.cfg.StackTraceAttributeKey); ok {
-				attributes.PutStr(p.cfg.OriginalStackTraceKey, originalStackTrace.Str())
-			}
+			sourceFiles.CopyTo(attributes.PutEmptySlice(p.cfg.OriginalSourceFilesAttributeKey))
+			attributes.PutStr(p.cfg.OriginalStackTraceKey, rawStackTrace.Str())
 		}
 	}
 

--- a/proguardprocessor/log_processor_test.go
+++ b/proguardprocessor/log_processor_test.go
@@ -779,6 +779,8 @@ func TestProcessLogRecord_ParsedRouteWithSymbolication(t *testing.T) {
 		OriginalClassesAttributeKey:           "original_classes",
 		OriginalMethodsAttributeKey:           "original_methods",
 		OriginalLinesAttributeKey:             "original_lines",
+		OriginalStackTraceKey: 			       "original_stack_trace",
+		PreserveStackTrace:                    true,
 		ExceptionTypeAttributeKey:             "exception_type",
 		ExceptionMessageAttributeKey:          "exception_message",
 		ProguardUUIDAttributeKey:              "uuid",
@@ -827,6 +829,16 @@ Caused by: java.lang.NullPointerException
 
 	processor.processLogRecord(context.Background(), lr, resourceAttrs)
 
+	// Verify symbolication succeeded
+	failed, ok := attrs.Get("symbolication_failed")
+	assert.True(t, ok)
+	assert.False(t, failed.Bool())
+
+	// Verify original stack trace is preserved
+	originalStackTrace, ok := attrs.Get("original_stack_trace")
+	assert.True(t, ok)
+	assert.Equal(t, rawStackTrace, originalStackTrace.Str())
+
 	// Verify exception type and message were set
 	exceptionType, ok := attrs.Get("exception_type")
 	assert.True(t, ok)
@@ -853,12 +865,7 @@ Caused by: java.lang.NullPointerException
 	assert.Contains(t, stackTrace.Str(), "Caused by: java.lang.NullPointerException")
 	assert.Contains(t, stackTrace.Str(), "... 5 more")
 
-	// Verify symbolication succeeded
-	failed, ok := attrs.Get("symbolication_failed")
-	assert.True(t, ok)
-	assert.False(t, failed.Bool())
-
-	// Verify that structured stack trace attributes were not populated
+	// Verify that structured stack trace attributes were NOT populated
 	_, ok = attrs.Get("classes")
 	assert.False(t, ok)
 	_, ok = attrs.Get("methods")

--- a/proguardprocessor/log_processor_test.go
+++ b/proguardprocessor/log_processor_test.go
@@ -555,6 +555,7 @@ func TestProcessLogRecord_PreserveStackTrace(t *testing.T) {
 		OriginalClassesAttributeKey:     "original_classes",
 		OriginalMethodsAttributeKey:     "original_methods",
 		OriginalLinesAttributeKey:       "original_lines",
+		OriginalSourceFilesAttributeKey: "original_source_files",
 		OriginalStackTraceKey:           "original_stack_trace",
 	}
 
@@ -596,6 +597,21 @@ func TestProcessLogRecord_PreserveStackTrace(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, originalClasses.Slice().Len())
 	assert.Equal(t, "com.example.Class", originalClasses.Slice().At(0).Str())
+
+	originalMethods, ok := attrs.Get("original_methods")
+	assert.True(t, ok)
+	assert.Equal(t, 1, originalMethods.Slice().Len())
+	assert.Equal(t, "method1", originalMethods.Slice().At(0).Str())
+
+	originalLines, ok := attrs.Get("original_lines")
+	assert.True(t, ok)
+	assert.Equal(t, 1, originalLines.Slice().Len())
+	assert.Equal(t, int64(42), originalLines.Slice().At(0).Int())
+
+	originalSourceFiles, ok := attrs.Get("original_source_files")
+	assert.True(t, ok)
+	assert.Equal(t, 1, originalSourceFiles.Slice().Len())
+	assert.Equal(t, "Class.java", originalSourceFiles.Slice().At(0).Str())
 
 	originalStackTrace, ok := attrs.Get("original_stack_trace")
 	assert.True(t, ok)
@@ -779,6 +795,7 @@ func TestProcessLogRecord_ParsedRouteWithSymbolication(t *testing.T) {
 		OriginalClassesAttributeKey:           "original_classes",
 		OriginalMethodsAttributeKey:           "original_methods",
 		OriginalLinesAttributeKey:             "original_lines",
+		OriginalSourceFilesAttributeKey:       "original_source_files",
 		OriginalStackTraceKey: 			       "original_stack_trace",
 		PreserveStackTrace:                    true,
 		ExceptionTypeAttributeKey:             "exception_type",
@@ -879,6 +896,8 @@ Caused by: java.lang.NullPointerException
 	_, ok = attrs.Get("original_methods")
 	assert.False(t, ok)
 	_, ok = attrs.Get("original_lines")
+	assert.False(t, ok)
+	_, ok = attrs.Get("original_source_files")
 	assert.False(t, ok)
 
 	parsingMethod, ok := attrs.Get("parsing_method")


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

Stack trace preservation was missing from the collector-parsed route on the proguard processor. Adding that in so users can see their minified stack traces.

The structured stack trace route preserves the original structured stack trace attributes alongside the stack trace. However, it was missing preservation of the source files attribute key. Adding that in a config option + setting that attribute.

## How to verify that this has the expected result
Added tests, all tests should be passing.

---

- [x] CHANGELOG is updated
- [x] README is updated with documentation
