### PR TITLE
feat: update dsym symbolicator to work with new otel json stacktrace format

### DIFF
--- a/dsymprocessor/CHANGELOG.md
+++ b/dsymprocessor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: add support for new OTel MetricKit stacktrace JSON format (#135) | @beekhc
 - feat: add optional language check to processors (#133) | @jairo-mendoza
 - refactor: improve parity between processors' configs (#131) | @jairo-mendoza
 

--- a/dsymprocessor/symbolicator_test.go
+++ b/dsymprocessor/symbolicator_test.go
@@ -28,23 +28,24 @@ func TestDSYMSymbolicator(t *testing.T) {
 	assert.NoError(t, err)
 	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, 128, fs, tb, attributes)
 
+	offset := uint64(100436)
 	baseFrame := MetricKitCallStackFrame{
 		BinaryUUID:                  "6A8CB813-45F6-3652-AD33-778FD1EAB196",
-		OffsetIntoBinaryTextSegment: 100436,
+		OffsetIntoBinaryTextSegment: &offset,
 		BinaryName:                  "chateaux-bufeaux",
 	}
-	sf, err := sym.symbolicateFrame(ctx, baseFrame.BinaryUUID, "Chateaux Bufeaux", baseFrame.OffsetIntoBinaryTextSegment)
+	sf, err := sym.symbolicateFrame(ctx, baseFrame.BinaryUUID, "Chateaux Bufeaux", *baseFrame.OffsetIntoBinaryTextSegment)
 	line := formatMetricKitStackFrames(baseFrame, sf)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "chateaux-bufeaux			0x18854 main (/Users/mustafa/hny/chateaux-bufeaux-ios/Chateaux Bufeaux/Chateaux_BufeauxApp.swift:0) + 100372", line)
 
 	// UUID doesn't exist
-	_, err = sym.symbolicateFrame(ctx, "2DBDCA05-2BAA-3BFE-9EF3-15A157D84058", "Chateaux Bufeaux", baseFrame.OffsetIntoBinaryTextSegment)
+	_, err = sym.symbolicateFrame(ctx, "2DBDCA05-2BAA-3BFE-9EF3-15A157D84058", "Chateaux Bufeaux", *baseFrame.OffsetIntoBinaryTextSegment)
 	assert.Error(t, err)
 
 	// binary doesn't exist in the dSYM
-	_, err = sym.symbolicateFrame(ctx, baseFrame.BinaryUUID, "other binary", baseFrame.OffsetIntoBinaryTextSegment)
+	_, err = sym.symbolicateFrame(ctx, baseFrame.BinaryUUID, "other binary", *baseFrame.OffsetIntoBinaryTextSegment)
 	assert.Error(t, err)
 
 	// // nothing at that offset
@@ -72,12 +73,13 @@ func TestDSYMSymbolicatorCache(t *testing.T) {
 	assert.Equal(t, 0, sym.cache.Len())
 
 	// First symbolication should add to cache
+	offset := uint64(100436)
 	baseFrame := MetricKitCallStackFrame{
 		BinaryUUID:                  "6A8CB813-45F6-3652-AD33-778FD1EAB196",
-		OffsetIntoBinaryTextSegment: 100436,
+		OffsetIntoBinaryTextSegment: &offset,
 		BinaryName:                  "chateaux-bufeaux",
 	}
-	sf, err := sym.symbolicateFrame(ctx, baseFrame.BinaryUUID, "Chateaux Bufeaux", baseFrame.OffsetIntoBinaryTextSegment)
+	sf, err := sym.symbolicateFrame(ctx, baseFrame.BinaryUUID, "Chateaux Bufeaux", *baseFrame.OffsetIntoBinaryTextSegment)
 	line := formatMetricKitStackFrames(baseFrame, sf)
 
 	assert.NoError(t, err)


### PR DESCRIPTION

## Which problem is this PR solving?

1. Updates the dSYM JSON stacktrace parser to accept the new [OTel MetricKit Stacktrace JSON format](https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/Instrumentation/MetricKit/StackTraceFormat.md).
2. Removes the way these stack traces were reversed, since it seems from our test data that these stacks were already in the desired order (for both the old and new formats).

## Short description of the changes

Because the formats are similar, and we don't want to parse the JSON twice, I merged them into the existing JSON structs.

## How to verify that this has the expected result

New tests were added for the new format.
Old tests were modified to update the expected stacktrace order.

---

- [x] CHANGELOG is updated
N/A ~- [ ] README is updated with documentation~
