### PR TITLE
feat: Emit parity check telemetry (for internal testing)

### DIFF
--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Emit parity check telemetry (for internal testing) (#136) | @jairo-mendoza
 - feat: add optional language check to processors (#133) | @jairo-mendoza
 - feat(sourcemap-processor): Implement collector-side parsing (#132) | @jairo-mendoza
 - refactor: improve parity between processors' configs (#131) | @jairo-mendoza

--- a/sourcemapprocessor/config.go
+++ b/sourcemapprocessor/config.go
@@ -101,6 +101,7 @@ type Config struct {
 	// through both the structured route (TraceKit) and the collector-side parsing route
 	// (Sourcemap Processor) and the results are compared. Parity attributes are added
 	// to the current span/log.
+	// NOTE: This is for internal testing purposes only and will be removed in the future.
 	EnableParityChecking bool `mapstructure:"enable_parity_checking"`
 }
 

--- a/sourcemapprocessor/config.go
+++ b/sourcemapprocessor/config.go
@@ -96,6 +96,12 @@ type Config struct {
 	// If the signal's language attribute matches any value in this list, the processor will run.
 	// If empty (default), the processor will process all signals regardless of language.
 	AllowedLanguages []string `mapstructure:"allowed_languages"`
+
+	// EnableParityChecking enables parity checking mode where stacktraces are processed
+	// through both the structured route (TraceKit) and the collector-side parsing route
+	// (Sourcemap Processor) and the results are compared. Parity attributes are added
+	// to the current span/log.
+	EnableParityChecking bool `mapstructure:"enable_parity_checking"`
 }
 
 type LocalSourceMapConfiguration struct {

--- a/sourcemapprocessor/factory.go
+++ b/sourcemapprocessor/factory.go
@@ -48,6 +48,7 @@ func createDefaultConfig() component.Config {
 		SourceMapCacheSize:   128,
 		LanguageAttributeKey: "telemetry.sdk.language",
 		AllowedLanguages:     []string{}, // Empty by default, processes all signals
+		EnableParityChecking: false,      // Disabled by default
 	}
 }
 

--- a/sourcemapprocessor/parity.go
+++ b/sourcemapprocessor/parity.go
@@ -1,0 +1,117 @@
+package sourcemapprocessor
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// NOTE: This file contains parity checking logic for comparing TraceKit (structured) vs
+// Collector-side parsing routes. This is for internal testing purposes and will be removed
+// in the future once parity is validated.
+
+// parityStatus represents the status of a parity check between two parsing routes
+type parityStatus string
+
+const (
+	// All fields of the parsed frame are identical between routes.
+	parityStatusConsistent parityStatus = "consistent"
+	// Resulting field has values that are missing, different, or otherwise inconsistent between routes.
+	parityStatusDifferent parityStatus = "different"
+	// TraceKit failed to parse but Sourcemap Processor succeeded.
+	parityStatusTracekitFailed parityStatus = "tracekit-failed"
+	// Processor parser failed to parse but TraceKit succeeded.
+	parityStatusProcessorParserFailed parityStatus = "processor-parser-failed"
+	// Stackframe failed to parse in both routes.
+	parityStatusParsingFailed parityStatus = "all-parsing-failed"
+)
+
+// frameComparisonType represents the result of comparing a stack frame between routes
+type frameComparisonType string
+
+const (
+	// Stack Frame is different between both libraries.
+	frameComparisonDifferent frameComparisonType = "different"
+	// Stack Frame is consistent between both libraries.
+	frameComparisonConsistent frameComparisonType = "consistent"
+)
+
+// addParityCheckAttributes adds parity check results as attributes to the current span/log
+// Compares TraceKit (structured attributes) vs Collector-side parsed frames directly
+func addParityCheckAttributes(
+	attributes pcommon.Map,
+	tracekitLines, tracekitColumns, tracekitFunctions, tracekitUrls pcommon.Slice,
+	parsedStackTrace *stackTrace,
+	duration time.Duration,
+) {
+	// Copy TraceKit slices directly
+	tracekitLines.CopyTo(attributes.PutEmptySlice("tracekit.lines"))
+	tracekitColumns.CopyTo(attributes.PutEmptySlice("tracekit.columns"))
+	tracekitFunctions.CopyTo(attributes.PutEmptySlice("tracekit.functions"))
+	tracekitUrls.CopyTo(attributes.PutEmptySlice("tracekit.urls"))
+
+	// Extract processor-parsed frames into slices
+	processorLines := attributes.PutEmptySlice("processorParser.lines")
+	processorColumns := attributes.PutEmptySlice("processorParser.columns")
+	processorFunctions := attributes.PutEmptySlice("processorParser.functions")
+	processorUrls := attributes.PutEmptySlice("processorParser.urls")
+
+	if parsedStackTrace != nil {
+		for _, frame := range parsedStackTrace.stackFrames {
+			processorUrls.AppendEmpty().SetStr(frame.url)
+			processorFunctions.AppendEmpty().SetStr(frame.funcName)
+			if frame.line != nil {
+				processorLines.AppendEmpty().SetInt(int64(*frame.line))
+			} else {
+				processorLines.AppendEmpty().SetInt(-1)
+			}
+			if frame.column != nil {
+				processorColumns.AppendEmpty().SetInt(int64(*frame.column))
+			} else {
+				processorColumns.AppendEmpty().SetInt(-1)
+			}
+		}
+	}
+
+	// Validate TraceKit data (all slices must have same length)
+	tracekitValid := tracekitLines.Len() == tracekitColumns.Len() &&
+		tracekitLines.Len() == tracekitFunctions.Len() &&
+		tracekitLines.Len() == tracekitUrls.Len()
+
+	processorValid := parsedStackTrace != nil
+
+	status := parityStatusConsistent
+	totalMismatches := 0
+	comparisonTypes := attributes.PutEmptySlice("parity.stackframe.comparison")
+
+	// Determine status based on both routes' validity
+	if !tracekitValid && !processorValid {
+		status = parityStatusParsingFailed
+	} else if !tracekitValid && processorValid {
+		status = parityStatusTracekitFailed
+	} else if tracekitValid && !processorValid {
+		status = parityStatusProcessorParserFailed
+	} else if tracekitColumns.Len() != processorColumns.Len() {
+		status = parityStatusDifferent // There's missing data between the 2 libraries
+	} else {
+		// Check the contents of both, should have same array size at this point
+		for i := 0; i < processorColumns.Len(); i++ {
+			if processorColumns.At(i).Int() != tracekitColumns.At(i).Int() ||
+				processorLines.At(i).Int() != tracekitLines.At(i).Int() ||
+				processorFunctions.At(i).Str() != tracekitFunctions.At(i).Str() ||
+				processorUrls.At(i).Str() != tracekitUrls.At(i).Str() {
+				comparisonTypes.AppendEmpty().SetStr(string(frameComparisonDifferent))
+				status = parityStatusDifferent // we only need one frame to be off for the parsing to be different
+				totalMismatches += 1
+			} else {
+				comparisonTypes.AppendEmpty().SetStr(string(frameComparisonConsistent))
+			}
+		}
+	}
+
+	
+	// Set summary attributes
+	attributes.PutStr("parity.status", string(status))
+	attributes.PutInt("parity.totalMismatches", int64(totalMismatches))
+	attributes.PutDouble("parity.duration", duration.Seconds())
+}

--- a/sourcemapprocessor/parity.go
+++ b/sourcemapprocessor/parity.go
@@ -113,5 +113,5 @@ func addParityCheckAttributes(
 	// Set summary attributes
 	attributes.PutStr("parity.status", string(status))
 	attributes.PutInt("parity.totalMismatches", int64(totalMismatches))
-	attributes.PutDouble("parity.duration", duration.Seconds())
+	attributes.PutDouble("parity.processorParsingDuration", duration.Seconds())
 }

--- a/sourcemapprocessor/parity.go
+++ b/sourcemapprocessor/parity.go
@@ -58,17 +58,27 @@ func addParityCheckAttributes(
 
 	if parsedStackTrace != nil {
 		for _, frame := range parsedStackTrace.stackFrames {
-			processorUrls.AppendEmpty().SetStr(frame.url)
-			processorFunctions.AppendEmpty().SetStr(frame.funcName)
+			if frame.url != "" {
+				processorUrls.AppendEmpty().SetStr(frame.url)
+			} else {
+				processorUrls.AppendEmpty()
+			}
+
+			if frame.funcName != "" {
+				processorFunctions.AppendEmpty().SetStr(frame.funcName)
+			} else {
+				processorFunctions.AppendEmpty()
+			}
+			
 			if frame.line != nil {
 				processorLines.AppendEmpty().SetInt(int64(*frame.line))
 			} else {
-				processorLines.AppendEmpty().SetInt(-1)
+				processorLines.AppendEmpty()
 			}
 			if frame.column != nil {
 				processorColumns.AppendEmpty().SetInt(int64(*frame.column))
 			} else {
-				processorColumns.AppendEmpty().SetInt(-1)
+				processorColumns.AppendEmpty()
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

#### Summary

Added parity checking functionality to compare parsing results between TraceKit (structured attributes) and our new collector-side stacktrace parser when processing JavaScript stack traces.

#### Changes

  - Added parity.go: New module implementing frame-by-frame comparison logic between two parsing routes
    - Position-based comparison: compares frames at matching indices for url, line, column, and function name
    - Exports parity status (consistent, different, or various failure states) and per-frame comparison results
    - Tracks total mismatch count and parsing duration
  - Added EnableParityChecking config option: Opt-in flag to enable parity checking (disabled by default)
  - Modified processor.go: When parity checking is enabled and both structured attributes and raw stack trace are present, runs both parsing routes and adds comparison attributes to the span/log

#### Technical Details

  The parity checker compares frames at the same position in both result arrays. Frames must match in count, order, and all field values (url, line, column, function) to be marked as consistent. Results are attached as telemetry attributes for analysis.

**Note: This is temporary testing infrastructure that will be removed once parity between the two parsing routes is validated.**

## How to verify that this has the expected result

---

- [x] CHANGELOG is updated
- [ ] README is updated with documentation
