### PR TITLE
fix(sourcemap-processor): add handling for anonymous urls

### DIFF
--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(sourcemap-processor): add handling for anonymous urls #141
+
 ## v1.0.1 - 2025/12/16
 
 ### ✨ Features

--- a/sourcemapprocessor/processor.go
+++ b/sourcemapprocessor/processor.go
@@ -305,6 +305,20 @@ func (sp *symbolicatorProcessor) processThrow(ctx context.Context, attributes pc
 
 		sp.telemetryBuilder.ProcessorTotalProcessedFrames.Add(ctx, 1, sp.attributes)
 
+		// Skip symbolication for anonymous frames
+		if url == "<anonymous>" {
+			stack = append(stack, fmt.Sprintf("    at %s (<anonymous>)", function))
+
+			// Only populate output slices for structured route
+			if parsedStackTrace == nil {
+				mappedColumns.AppendEmpty().SetInt(column)
+				mappedFunctions.AppendEmpty().SetStr(function)
+				mappedLines.AppendEmpty().SetInt(line)
+				mappedUrls.AppendEmpty().SetStr(url)
+			}
+			continue
+		}
+
 		// Skip symbolication for native frames
 		// Examples: "at call (native)", "[native code]"
 		if url == "(native)" || url == "[native code]" {

--- a/sourcemapprocessor/stack_trace_parser_test.go
+++ b/sourcemapprocessor/stack_trace_parser_test.go
@@ -831,6 +831,23 @@ func TestStackTraceParser(t *testing.T) {
 			},
 			expectedMode: parseModeStack,
 		},
+		{
+			name:          "Chrome error with anonymous url",
+			exceptionName: "Error",
+			exceptionMsg:  "test error",
+			stack: "Error: test error\n" +
+				"    at JSON.parse (<anonymous>)\n" +
+				"    at foo (http://example.com/bundle.js:1:100)\n" +
+				"    at async http://example.com/bundle.js:1:200",
+			expectedName:    "Error",
+			expectedMessage: "test error",
+			expectedFrames: []stackFrame{
+				{url: "<anonymous>", funcName: "JSON.parse", line: nil, column: nil},
+				{url: "http://example.com/bundle.js", funcName: "foo", line: intPtr(1), column: intPtr(100)},
+				{url: "http://example.com/bundle.js", funcName: "async", line: intPtr(1), column: intPtr(200)},
+			},
+			expectedMode: parseModeStack,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

The processor was throwing symbolication errors on frames with anonymous urls because the symbolication logic didn't know how to handle this edge case. Adding specail handling for `<anonymous` URL frames. We are skipping symbolication and printing out the frame as-is.

## How to verify that this has the expected result
Unit tests pass! Tested locally.

---

- [X] CHANGELOG is updated
- [ ] README is updated with documentation
