### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/frontend-observability
+* @honeycombio/eng-directors
 


### PR DESCRIPTION
Update codeowners to the `eng-directors` team.