### PR TITLE
fix(sourcemapprocessor): correct sourceMappingURL lookup when multiple are present

### DIFF
--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: correct sourceMappingURL lookup when multiple are present
+- fix(sourcemap-processor): correct sourceMappingURL lookup when multiple are present (#149) | @robbkidd 
 
 ## v1.0.3 - 2026/01/12
 

--- a/sourcemapprocessor/CHANGELOG.md
+++ b/sourcemapprocessor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: correct sourceMappingURL lookup when multiple are present
+
 ## v1.0.3 - 2026/01/12
 
 - maint: bump dependency to v1.45.0/v0.139.0 (#143) | @TylerHelmuth

--- a/sourcemapprocessor/store.go
+++ b/sourcemapprocessor/store.go
@@ -62,7 +62,7 @@ func (s *store) GetSourceMap(ctx context.Context, url string, uuid string) ([]by
 	}
 
 	// the sourceMappingURL match we want is the last one
-	mapName := string(matches[len(matches)-1][1]) # matches[last-match][the-first-capture]
+	mapName := string(matches[len(matches)-1][1]) // matches[last-match][the-first-capture]
 
 	// the map name is relative to the source file
 	path = filepath.Join(filepath.Dir(path), mapName)

--- a/sourcemapprocessor/store.go
+++ b/sourcemapprocessor/store.go
@@ -62,7 +62,7 @@ func (s *store) GetSourceMap(ctx context.Context, url string, uuid string) ([]by
 	}
 
 	// the sourceMappingURL match we want is the last one
-	mapName := string(matches[len(matches)-1][1])
+	mapName := string(matches[len(matches)-1][1]) # matches[last-match][the-first-capture]
 
 	// the map name is relative to the source file
 	path = filepath.Join(filepath.Dir(path), mapName)

--- a/sourcemapprocessor/store.go
+++ b/sourcemapprocessor/store.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	mappingURLRegex                  = regexp.MustCompile(`\/\/[#@]\s(sourceMappingURL)=\s*(\S+)`)
+	mappingURLRegex                  = regexp.MustCompile(`//[#@]\s*sourceMappingURL\s*=\s*(\S+)`)
 	errFailedToFindSourceFile        = fmt.Errorf("failed to find source file")
 	errFailedToFindSourceMapLocation = fmt.Errorf("failed to find source map location")
 	errFailedToFindSourceMap         = fmt.Errorf("failed to find source map")
@@ -55,14 +55,14 @@ func (s *store) GetSourceMap(ctx context.Context, url string, uuid string) ([]by
 		return nil, nil, fmt.Errorf("%w: %s", errFailedToFindSourceFile, path)
 	}
 
-	matches := mappingURLRegex.FindSubmatch(source)
+	matches := mappingURLRegex.FindAllSubmatch(source, -1)
 
-	if len(matches) <= 0 {
+	if len(matches) == 0 {
 		return nil, nil, fmt.Errorf("%w: %s", errFailedToFindSourceMapLocation, path)
 	}
 
-	// the capture group we want is the last one
-	mapName := string(matches[len(matches)-1])
+	// the sourceMappingURL match we want is the last one
+	mapName := string(matches[len(matches)-1][1])
 
 	// the map name is relative to the source file
 	path = filepath.Join(filepath.Dir(path), mapName)

--- a/sourcemapprocessor/store_test.go
+++ b/sourcemapprocessor/store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -12,18 +13,18 @@ func TestFileStore(t *testing.T) {
 	ctx := context.Background()
 
 	fs, err := newFileStore(ctx, zaptest.NewLogger(t), &LocalSourceMapConfiguration{Path: "../test_assets"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	source, sMap, err := fs.GetSourceMap(ctx, jsFile, "")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, source)
-	assert.NotEmpty(t, sMap)
+	require.NoError(t, err)
+	assert.Contains(t, string(source), "basic-mapping.js.map")
+	assert.Contains(t, string(sMap), "basic-mapping.js")
 
 	source, sMap, err = fs.GetSourceMap(ctx, uuidFile, uuid)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, source)
-	assert.NotEmpty(t, sMap)
+	require.NoError(t, err)
+	assert.Contains(t, string(source), "uuid-mapping.js.map")
+	assert.Contains(t, string(sMap), "uuid-mapping.js")
 
-	source, sMap, err = fs.GetSourceMap(ctx, noFile, "")
+	_, _, err = fs.GetSourceMap(ctx, noFile, "")
 	assert.ErrorIs(t, err, errFailedToFindSourceFile)
 }

--- a/sourcemapprocessor/symbolicator_test.go
+++ b/sourcemapprocessor/symbolicator_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor/internal/metadata"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap/zaptest"
 )
 
-var (
+const (
 	jsFile   = "https://www.honeycomb.io/assets/js/basic-mapping.js"
 	noFile   = "https://www.honeycomb.io/assets/js/does-not-exist.js"
 	uuid     = "e63db37d-9886-452a-8e56-2250dcc20102"
@@ -38,8 +39,8 @@ func TestSymbolicator(t *testing.T) {
 
 	// The basic case.
 	sf, err := sym.symbolicate(ctx, 0, 34, "b", jsFile, "")
+	require.NoError(t, err)
 	line := formatStackFrame(sf)
-	assert.NoError(t, err)
 	assert.Equal(t, "    at bar(basic-mapping-original.js:8:1)", line)
 
 	// When there is no url.
@@ -80,7 +81,7 @@ func TestSymbolicatorCache(t *testing.T) {
 	)
 
 	fs, err := newFileStore(ctx, zaptest.NewLogger(t), &LocalSourceMapConfiguration{Path: "../test_assets"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sym, _ := newBasicSymbolicator(ctx, 5*time.Second, 128, fs, tb, attributes)
 
 	// Cache should be empty to start
@@ -88,6 +89,7 @@ func TestSymbolicatorCache(t *testing.T) {
 
 	// First symbolication should add to cache
 	sf, err := sym.symbolicate(ctx, 0, 34, "b", jsFile, "")
+	require.NoError(t, err)
 	line := formatStackFrame(sf)
 
 	assert.NoError(t, err)
@@ -153,7 +155,7 @@ func TestSymbolicatorCacheWithUUID(t *testing.T) {
 
 	// Symbolicate with UUID
 	sf1, err := sym.symbolicate(ctx, 0, 34, "b", uuidFile, uuid)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", sf1.FunctionName)
 
 	// Cache should have one entry (url|uuid)
@@ -176,7 +178,7 @@ func TestSymbolicatorCacheWithUUID(t *testing.T) {
 	// Symbolicate same URL with NO UUID
 	// This should also create a separate cache entry
 	sf3, err := sym.symbolicate(ctx, 0, 34, "b", jsFile, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "bar", sf3.FunctionName)
 
 	// Cache should now have two entries: "uuid-mapping.js|<uuid>" and "jsFile"

--- a/sourcemapprocessor/symbolicator_test.go
+++ b/sourcemapprocessor/symbolicator_test.go
@@ -41,7 +41,7 @@ func TestSymbolicator(t *testing.T) {
 	sf, err := sym.symbolicate(ctx, 0, 34, "b", jsFile, "")
 	require.NoError(t, err)
 	line := formatStackFrame(sf)
-	assert.Equal(t, "    at bar(basic-mapping-original.js:8:1)", line)
+	assert.Equal(t, "    at bar(basic-mapping.js:8:1)", line)
 
 	// When there is no url.
 	sf, err = sym.symbolicate(ctx, 0, 34, "b", "", "")
@@ -53,7 +53,7 @@ func TestSymbolicator(t *testing.T) {
 	sf, err = sym.symbolicate(ctx, 0, 34, "b", uuidFile, uuid)
 	line = formatStackFrame(sf)
 	assert.NoError(t, err)
-	assert.Equal(t, "    at bar(uuid-mapping-original.js:8:1)", line)
+	assert.Equal(t, "    at bar(uuid-mapping.js:8:1)", line)
 
 	// When the file is missing.
 	_, err = sym.symbolicate(ctx, 0, 34, "b", noFile, "")
@@ -93,7 +93,7 @@ func TestSymbolicatorCache(t *testing.T) {
 	line := formatStackFrame(sf)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "    at bar(basic-mapping-original.js:8:1)", line)
+	assert.Equal(t, "    at bar(basic-mapping.js:8:1)", line)
 
 	// Cache should have one entry
 	assert.Equal(t, 1, sym.cache.Len())

--- a/test_assets/basic-mapping.js
+++ b/test_assets/basic-mapping.js
@@ -1,2 +1,4 @@
 function foo() { return 42 } function bar() { return 24 } foo(); bar();
+var worker=new Blob(['function doWork(){};\n//# sourceMappingURL=embedded-content.js.map\n'],{type:"text/javascript;charset=utf-8"});
+var worker2=new Blob(['function doWork(){};\n//# sourceMappingURL=embedded-content.js.map\n'],{type:"text/javascript;charset=utf-8"});
 //# sourceMappingURL=basic-mapping.js.map

--- a/test_assets/basic-mapping.js.map
+++ b/test_assets/basic-mapping.js.map
@@ -1,6 +1,6 @@
 {
   "version":3,
   "names": ["foo","bar"],
-  "sources": ["basic-mapping-original.js"],
+  "sources": ["basic-mapping.js"],
   "mappings":"AAAA,SAASA,MACP,OAAO,EACT,CACA,SAASC,MACP,OAAO,EACT,CACAD,MACAC"
 }

--- a/test_assets/e63db37d-9886-452a-8e56-2250dcc20102/uuid-mapping.js.map
+++ b/test_assets/e63db37d-9886-452a-8e56-2250dcc20102/uuid-mapping.js.map
@@ -1,6 +1,6 @@
 {
   "version":3,
   "names": ["foo","bar"],
-  "sources": ["uuid-mapping-original.js"],
+  "sources": ["uuid-mapping.js"],
   "mappings":"AAAA,SAASA,MACP,OAAO,EACT,CACA,SAASC,MACP,OAAO,EACT,CACAD,MACAC"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We've seen errors from symbolicator when there are sourceMappingURL entries in strings within the minified JS before the final one at the bottom of the file.

## Short description of the changes

### add failing test(s) to reproduce the problem
* added multiple `sourceMappingURL=` entries to the basic-mapping fixture
* updated the `"sources"` entries in .map files to be more like real .maps
* required that there be no error before continuing with assertions in several tests that panic now that the function fails when multiple source map URLs are present

### find all `sourceMappingURL=` entries in mini-source, use last one

`FindSubmatch()` returns the first match. Some minified source contains embedded sourceMappingURL strings.

Use `FindAllSubmatch()` instead to return all matches. The map entry for the file is always on the last line, so use the last match.

Regex changes:
* don't need to escape /
* don't need to capture the "sourceMappingURL" literal
* loosen whitespace requirements around the entry

## How to verify that this has the expected result

Presumably the test suite!

---

- [x] CHANGELOG is updated
- ~README is updated with documentation~
